### PR TITLE
Update pyproject.toml and tox.ini.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ exclude = [
     "dist",
     "venv",
     "report",
+    "lib",
 ]
 
 [tool.ruff.format]

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,12 @@ pass_env =
 description = Apply coding style standards to code
 deps =
     ruff
+    codespell
+    tomli
 commands =
+    codespell -w .
     ruff format .
-    ruff check --fix .
+    ruff check --fix --exit-zero --silent . # we only want --fix feature here
 
 [testenv:lint]
 description = Check code against coding style standards


### PR DESCRIPTION
1. `tox -e format` was doing lint
2. `lib` directory was not excluded.