### PR TITLE
Exclude "lib" while running mypy.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,4 @@ warn_unused_configs = true
 warn_unreachable = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
-exclude = ['.eggs', '.git', '.tox', '.venv', '.build', 'build', 'report', 'tests']
+exclude = [".eggs", ".git", ".tox", ".venv", ".build", "build", "report", "tests", "lib"]


### PR DESCRIPTION
The "lib" directory is fetching from the ops's library which does not necessary follow "mypy" rule. We should not validate it from our repository unless we have our own library. 