### PR TITLE
Remove preserving snap state logic in `SnapService.configure`.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,9 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         snap_service = get_installed_snap_service(SNAP_NAME, SNAP_SERVICE_NAME)
 
         if not snap_service:
-            event.add_status(BlockedStatus("snap service is not installed, please check snap service"))
+            event.add_status(
+                BlockedStatus("snap service is not installed, please check snap service")
+            )
         elif not snap_service.is_active():
             event.add_status(
                 BlockedStatus("snap service is not running, please check snap service")

--- a/src/service.py
+++ b/src/service.py
@@ -35,15 +35,7 @@ class SnapService:
             logger.warning("empty snap config: %s, skipping...", snap_config)
             return
 
-        # Store is previous state, for later use.
-        previously_active = self.is_active()
-
         self.snap_client.set(snap_config, typed=True)
-
-        # Changing snap configuration will also restart the snap service, so we
-        # need to explicitly preserve the state of the snap service.
-        if not previously_active:
-            self.stop()
 
 
 def snap_install(resource: str, snap_service: str) -> Optional[SnapService]:


### PR DESCRIPTION
This PR basically remove the unnecessary logic in the `SnapService.configure` because snap service now will not restart when it's configured.