### PR TITLE
Add lint and unit test workflow.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,38 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  code-quality:
+    name: Run code quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Run unit test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run unit test
+        run: tox -e unit

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,3 @@
+# For cos_agent library
+cosl
+pydantic < 2

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,6 +16,5 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    def test_dummy_install(self):
-        """Dummy test case."""
-        self.harness.charm.on.install.emit()
+    def test_null(self):
+        """Remove me."""

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ deps =
     pytest
     coverage[toml]
     -r {toxinidir}/requirements.txt
+    -r {toxinidir}/tests/unit/requirements.txt
 commands =
     coverage run --source={toxinidir}/src \
                  -m pytest \


### PR DESCRIPTION
Add lint and unit test workflow when PR is created on the `main` branch.

See example [runs](https://github.com/chanchiwai-ray/openstack-exporter-operator/pull/1) of the workflow from my fork.