### PR TITLE
[WIP] Add workflow for releasing charm to `latest/edge` channel

### DIFF
--- a/.github/workflows/_check_file_update.yaml
+++ b/.github/workflows/_check_file_update.yaml
@@ -1,0 +1,15 @@
+name: Check File Updates
+
+on:
+  workflow_call:
+
+jobs:
+
+  check-file-updates:
+    name: Check updates for files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v4
+      - name: Check differences
+        run: make check-dashboard-updates

--- a/.github/workflows/_quality_check.yaml
+++ b/.github/workflows/_quality_check.yaml
@@ -1,0 +1,42 @@
+name: Quality Checks
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: false
+        description: "Python version"
+        type: string
+        default: "3.10"
+
+jobs:
+
+  code-quality:
+    name: Run code quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Run unit test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run unit test
+        run: tox -e unit

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -1,0 +1,30 @@
+name: Upload and Release Charm
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        type: string
+        default: "latest/edge"
+        description: "charmhub channel to release"
+        required: false
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+      GITHUB_TOKEN:
+        required: true
+jobs:
+
+  release:
+    name: Release charm to charmhub
+    needs: [quality-checks]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Upload and release charm to latest/edge channel
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc # pre-release: supports all-in-one charmcraft.yaml
+        with:
+          channel: "${{ inputs.channel }}"
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -11,8 +11,6 @@ on:
     secrets:
       CHARMHUB_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 jobs:
 
   release:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,40 +8,11 @@ on:
 jobs:
 
   code-quality:
-    name: Run code quality checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -e lint
-
-  unit-test:
-    name: Run unit test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run unit test
-        run: tox -e unit
+    name: Run charm code quality checks
+    uses: ./.github/workflows/_quality_check.yaml
+    with:
+      python-version: "3.10"
 
   check-file-updates:
-    name: Check updates for grafana dashboard
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout local repository
-        uses: actions/checkout@v4
-      - name: Check differences
-        run: make check-dashboard-updates
+    name: Check updates for charm files
+    uses: ./.github/workflows/_check_file_update.yaml

--- a/.github/workflows/release-to-edge.yaml
+++ b/.github/workflows/release-to-edge.yaml
@@ -1,0 +1,23 @@
+name: Upload and Release Charm
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-to-edge
+  cancel-in-progress: true
+
+jobs:
+  quality-checks:
+    uses: ./.github/workflows/_quality_check.yaml
+    with:
+      python-version: "3.10"
+
+  release-to-edge:
+    needs: [quality-checks]
+    name: Release charm to latest/edge channel
+    uses: ./.github/workflows/_release.yaml
+    secrets: inherit
+    with:
+      channel: "latest/edge"


### PR DESCRIPTION
This PR adds the following:

- Refactor workflows for re-usability
- Add workflows for releasing charm to `latest/edge` channel when pushed to `main`

This workflow needs the following secrets to work properly:
- GITHUB_TOKEN
- CHARMHUB_TOKEN

**WIP**: depends on #24 