### PR TITLE
Add workflow for releasing charm to `latest/edge` channel

### DIFF
--- a/.github/workflows/_check_file_update.yaml
+++ b/.github/workflows/_check_file_update.yaml
@@ -1,0 +1,15 @@
+name: Check File Updates
+
+on:
+  workflow_call:
+
+jobs:
+
+  check-file-updates:
+    name: Check updates for files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v4
+      - name: Check differences
+        run: make check-dashboard-updates

--- a/.github/workflows/_quality_check.yaml
+++ b/.github/workflows/_quality_check.yaml
@@ -1,0 +1,42 @@
+name: Quality Checks
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: false
+        description: "Python version"
+        type: string
+        default: "3.10"
+
+jobs:
+
+  code-quality:
+    name: Run code quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Run unit test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run unit test
+        run: tox -e unit

--- a/.github/workflows/_quality_check.yaml
+++ b/.github/workflows/_quality_check.yaml
@@ -3,16 +3,26 @@ name: Quality Checks
 on:
   workflow_call:
     inputs:
+      tox-version:
+        required: false
+        description: "Tox version (default to latest)"
+        type: string
+        default: ""
       python-version:
         required: false
-        description: "Python version"
+        description: "Python version (default to 3.10)"
         type: string
         default: "3.10"
+      juju-channel:
+        required: false
+        description: "Juju snap channel (default to 3.1/stable)"
+        type: string
+        default: "3.1/stable"
 
 jobs:
 
-  code-quality:
-    name: Run code quality checks
+  lint-test:
+    name: Run lint test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -40,3 +50,24 @@ jobs:
         run: python3 -m pip install tox
       - name: Run unit test
         run: tox -e unit
+
+  integration-test:
+    needs: [lint-test, unit-test]
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    strategy:
+      fail-fast: false
+    with:
+      command: "tox -e integration"
+      juju-channel: ${{ inputs.juju-channel }}
+      tox-version: ${{ inputs.tox-version }}
+      nested-containers: false
+      timeout-minutes: 120
+      action-operator: false
+      external-controller: true
+      runs-on: "['self-hosted', 'runner-openstack-exporter']"
+      juju-controller: soleng-ci-ctrl
+      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAo="
+    secrets:
+      juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
+      juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}
+      openstack-auth-env: ${{ secrets.OPENSTACK_AUTH_ENV }}

--- a/.github/workflows/_quality_check.yaml
+++ b/.github/workflows/_quality_check.yaml
@@ -18,6 +18,13 @@ on:
         description: "Juju snap channel (default to 3.1/stable)"
         type: string
         default: "3.1/stable"
+    secrets:
+      JUJU_CONTROLLERS_YAML:
+        required: True
+      JUJU_ACCOUNTS_YAML:
+        required: True
+      OPENSTACK_AUTH_ENV:
+        required: True
 
 jobs:
 

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -1,0 +1,30 @@
+name: Upload and Release Charm
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        type: string
+        default: "latest/edge"
+        description: "charmhub channel to release"
+        required: false
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+      GITHUB_TOKEN:
+        required: true
+jobs:
+
+  release:
+    name: Release charm to charmhub
+    needs: [quality-checks]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Upload and release charm to latest/edge channel
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc # pre-release: supports all-in-one charmcraft.yaml
+        with:
+          channel: "${{ inputs.channel }}"
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -11,8 +11,6 @@ on:
     secrets:
       CHARMHUB_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 jobs:
 
   release:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,62 +7,14 @@ on:
 
 jobs:
 
-  code-quality:
-    name: Run code quality checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -e lint
-
-  unit-test:
-    name: Run unit test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run unit test
-        run: tox -e unit
+  check-code-quality:
+    name: Run charm code quality checks
+    uses: ./.github/workflows/_quality_check.yaml
+    with:
+      tox-version: ""
+      python-version: "3.10"
+      juju-channel: "3.1/stable"
 
   check-file-updates:
-    name: Check updates for grafana dashboard
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout local repository
-        uses: actions/checkout@v4
-      - name: Check differences
-        run: make check-dashboard-updates
-
-  integration-test:
-    needs: [code-quality, unit-test]
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
-    strategy:
-      fail-fast: false
-    with:
-      command: "tox -e integration"
-      juju-channel: "3.1/stable"
-      tox-version: ""
-      nested-containers: false
-      timeout-minutes: 120
-      action-operator: false
-      external-controller: true
-      runs-on: "['self-hosted', 'runner-openstack-exporter']"
-      juju-controller: soleng-ci-ctrl
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAo="
-    secrets:
-      juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
-      juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}
-      openstack-auth-env: ${{ secrets.OPENSTACK_AUTH_ENV }}
+    name: Check updates for charm files
+    uses: ./.github/workflows/_check_file_update.yaml

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,6 +10,7 @@ jobs:
   check-code-quality:
     name: Run charm code quality checks
     uses: ./.github/workflows/_quality_check.yaml
+    secrets: inherit
     with:
       tox-version: ""
       python-version: "3.10"

--- a/.github/workflows/release-to-edge.yaml
+++ b/.github/workflows/release-to-edge.yaml
@@ -12,6 +12,7 @@ jobs:
   check-code-quality:
     name: Run charm code quality checks
     uses: ./.github/workflows/_quality_check.yaml
+    secrets: inherit
     with:
       tox-version: ""
       python-version: "3.10"

--- a/.github/workflows/release-to-edge.yaml
+++ b/.github/workflows/release-to-edge.yaml
@@ -1,0 +1,26 @@
+name: Upload and Release Charm
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-to-edge
+  cancel-in-progress: true
+
+jobs:
+  check-code-quality:
+    name: Run charm code quality checks
+    uses: ./.github/workflows/_quality_check.yaml
+    with:
+      tox-version: ""
+      python-version: "3.10"
+      juju-channel: "3.1/stable"
+
+  release-to-edge:
+    needs: [check-code-quality]
+    name: Release charm to latest/edge channel
+    uses: ./.github/workflows/_release.yaml
+    secrets: inherit
+    with:
+      channel: "latest/edge"


### PR DESCRIPTION
This PR adds the following:

- Refactor workflows for re-usability
- Add workflows for releasing charm to `latest/edge` channel when pushed to `main`

This workflow needs the following secrets to work properly:
- GITHUB_TOKEN
- CHARMHUB_TOKEN
