### PR TITLE
Add client side configuration for GH Jira sync bot.

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,36 @@
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "SOLENG"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  components:
+    - openstack-exporter
+
+  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+  # If not specified, all issues will be synchronized
+  labels:
+    - bug
+    - enhancement
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  # add_gh_comment: false
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  # sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  # sync_comments: true
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  # epic_key: "MTC-296"
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story


### PR DESCRIPTION
See PR title.

Based on https://github.com/canonical/gh-jira-sync-bot; server side configuration was already done by the organization, so we only need to change client side configuration.