### PR TITLE
Make `lint` and `format` tox environment consistent.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ deps =
     mypy
 commands =
     codespell .
+    ruff format --diff .
     ruff check --no-fix .
     mypy --install-types --non-interactive .
 


### PR DESCRIPTION
Adding `ruff format --diff .` in the `lint` environment to make `lint` and `format` tox environment consistent.

Closes: #33 