### PR TITLE
Uncomment links metadata and link to new docs

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -47,8 +47,6 @@ links:
   - https://github.com/canonical/openstack-exporter-operator/issues
   source:
   - https://github.com/canonical/openstack-exporter-operator
-  website:
-  - https://charmhub.io/openstack-exporter
 
 resources:
   openstack-exporter:


### PR DESCRIPTION
New docs are being developed at https://discourse.charmhub.io/t/openstack-exporter-docs-index/13876 - currently they're minimal / not much different to what's already in the description in metadata.