### PR TITLE
feat: Provide cache configuration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -33,13 +33,23 @@ config:
         The openstack-exporter service (metrics endpoint for prometheus scraping)
         will listen at this port.
     ssl_ca:
-      default: ''
+      default: ""
       type: string
       description: |
         Custom SSL CA for keystone if required.
 
         The format should be the raw contents of a PEM encoded file.
         (no base64 encoding).
+    cache_ttl:
+      default: "300s"
+      type: string
+      description: |
+        TTL duration for cache expiry(eg. 10s, 11m, 1h)
+    cache:
+      default: false
+      type: boolean
+      description: |
+        Enable exporter cache globally
 
 
 links:

--- a/src/charm.py
+++ b/src/charm.py
@@ -183,6 +183,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
                 "cloud": CLOUD_NAME,
                 "os-client-config": str(OS_CLIENT_CONFIG),
                 "web": {"listen-address": f":{self.model.config['port']}"},
+                "cache": self.model.config["cache"],
+                "cache-ttl": self.model.config["cache_ttl"],
             }
         )
 

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,5 @@
 # For cos_agent library
 cosl
 pydantic < 2
+pytest
+pytest-mock

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,18 +3,55 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import unittest
-
 import ops
 import ops.testing
-from charm import OpenstackExporterOperatorCharm
+import pytest
+from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME, OpenstackExporterOperatorCharm
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
+class TestCharm:
+    def setup_method(self, _):
         self.harness = ops.testing.Harness(OpenstackExporterOperatorCharm)
-        self.addCleanup(self.harness.cleanup)
+
+    def teardown_method(self, _):
+        self.harness.cleanup()
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            ({"cache": False, "cache_ttl": "100s"}),
+            ({"cache": True, "cache_ttl": "200s"}),
+        ],
+    )
+    def test_config_changed(self, config, mocker):
+        mock_get_installed_snap_service = mocker.patch("charm.get_installed_snap_service")
+        mock_snap_service = mocker.Mock()
+        mock_get_installed_snap_service.return_value = mock_snap_service
+
         self.harness.begin()
 
-    def test_null(self):
-        """Remove me."""
+        mock_get_keystone_data = mocker.Mock()
+        mock_keystone_data = mocker.Mock()
+        mock_get_keystone_data.return_value = mock_keystone_data
+        self.harness.charm._get_keystone_data = mock_get_keystone_data
+
+        mock_write_cloud_config = mocker.Mock()
+        self.harness.charm._write_cloud_config = mock_write_cloud_config
+        self.harness.add_relation("cos-agent", "openstack-exporter")
+
+        self.harness.update_config(config)
+        self.harness.charm.on.config_changed.emit()
+
+        mock_get_installed_snap_service.assert_called_with(SNAP_NAME)
+        mock_snap_service.configure.assert_called_with(
+            {
+                "cloud": CLOUD_NAME,
+                "os-client-config": str(OS_CLIENT_CONFIG),
+                "web": {"listen-address": f":{config.get('port', 9180)}"},
+                "cache": config.get("cache", False),
+                "cache-ttl": config.get("cache_ttl", "300s"),
+            }
+        )
+        mock_write_cloud_config.assert_called_with(mock_keystone_data)
+        mock_snap_service.restart_and_enable.assert_called()
+        mock_snap_service.stop.assert_not_called()


### PR DESCRIPTION
* Add support for snap `cache` and `cache-ttl` configurations.
* Change unit test basic class to pytest and use pytest-mocker