### PR TITLE
Support Juju 3.4

### DIFF
--- a/.github/workflows/_quality_check.yaml
+++ b/.github/workflows/_quality_check.yaml
@@ -13,11 +13,6 @@ on:
         description: "Python version (default to 3.10)"
         type: string
         default: "3.10"
-      juju-channel:
-        required: false
-        description: "Juju snap channel (default to 3.1/stable)"
-        type: string
-        default: "3.1/stable"
     secrets:
       JUJU_CONTROLLERS_YAML:
         required: True
@@ -63,9 +58,13 @@ jobs:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - juju-channel: "3.4/stable"
+            command: "TEST_JUJU3=true make integration"  # using TEST_JUJU3 due to https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
     with:
-      command: "make integration"
-      juju-channel: ${{ inputs.juju-channel }}
+      command: ${{ matrix.command }}
+      juju-channel: ${{ matrix.juju-channel }}
       tox-version: ${{ inputs.tox-version }}
       nested-containers: false
       timeout-minutes: 120
@@ -77,4 +76,3 @@ jobs:
     secrets:
       juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
       juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}
-      openstack-auth-env: ${{ secrets.OPENSTACK_AUTH_ENV }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,9 +16,8 @@ jobs:
     uses: ./.github/workflows/_quality_check.yaml
     secrets: inherit
     with:
-      tox-version: ""
+      tox-version: ""  # latest tox
       python-version: "3.10"
-      juju-channel: "3.4/stable"
 
   check-file-updates:
     name: Check updates for charm files

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   check-code-quality:
@@ -14,7 +18,7 @@ jobs:
     with:
       tox-version: ""
       python-version: "3.10"
-      juju-channel: "3.1/stable"
+      juju-channel: "3.4/stable"
 
   check-file-updates:
     name: Check updates for charm files

--- a/.github/workflows/release-to-edge.yaml
+++ b/.github/workflows/release-to-edge.yaml
@@ -14,9 +14,8 @@ jobs:
     uses: ./.github/workflows/_quality_check.yaml
     secrets: inherit
     with:
-      tox-version: ""
+      tox-version: ""  # latest tox
       python-version: "3.10"
-      juju-channel: "3.1/stable"
 
   release-to-edge:
     needs: [check-code-quality]

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,6 @@ download-snap:
 	wget -q https://github.com/canonical/openstack-exporter-operator/releases/download/rev2/golang-openstack-exporter_amd64.snap -O ./golang-openstack-exporter_amd64.snap
 
 integration: build download-snap
-	CHARM_LOCATION=${CHARM_LOCATION} CHARM_SNAP_LOCATION=${CHARM_SNAP_LOCATION} tox -e integration
+	CHARM_LOCATION=${CHARM_LOCATION} CHARM_SNAP_LOCATION=${CHARM_SNAP_LOCATION} tox -e integration -- ${FUNC_ARGS}
 
 .PHONY: help update-charm-libs check-dashboard-updates clean build download-snap integration sync-dashboards

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,6 +2,5 @@ cosl # dependency from charm
 pydantic < 2 # dependency from charm
 python-openstackclient
 
-# FIXME: when zaza support libjuju 3.x, remove the pin
-git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/tests/integration/tests/bundles/jammy-yoga.yaml
+++ b/tests/integration/tests/bundles/jammy-yoga.yaml
@@ -4,6 +4,7 @@ series: jammy
 
 applications:
   openstack-exporter:
+    charm: openstack-exporter  # To be overridden by overlay
     num_units: 1
   grafana-agent:
     charm: grafana-agent

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ passenv =
     PYTHONPATH
     MODEL_SETTINGS
     CHARM_*
+    TEST_*
 
 [testenv:format]
 description = Apply coding style standards to code


### PR DESCRIPTION
- Changing to use of Juju 3.4 controller for testing instead of Juju 3.1
- Add workflow concurrency to avoid running multiple workflows on a single PR.