### PR TITLE
Update dashboards from upstream

### DIFF
--- a/src/grafana_dashboards/hypervisor-openstack-exporter-dashboard.json
+++ b/src/grafana_dashboards/hypervisor-openstack-exporter-dashboard.json
@@ -61,8 +61,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 4,
-        "x": 8,
+        "w": 6,
+        "x": 0,
         "y": 1
       },
       "id": 182,
@@ -128,8 +128,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 4,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 1
       },
       "id": 165,
@@ -193,8 +193,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 4,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 1
       },
       "id": 168,
@@ -258,8 +258,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 4,
-        "x": 20,
+        "w": 6,
+        "x": 18,
         "y": 1
       },
       "id": 179,
@@ -313,8 +313,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 12,
+        "w": 3,
+        "x": 6,
         "y": 6
       },
       "id": 166,
@@ -370,8 +370,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 14,
+        "w": 3,
+        "x": 9,
         "y": 6
       },
       "id": 167,
@@ -427,8 +427,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 16,
+        "w": 3,
+        "x": 12,
         "y": 6
       },
       "id": 169,
@@ -484,8 +484,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 18,
+        "w": 3,
+        "x": 15,
         "y": 6
       },
       "id": 170,
@@ -541,8 +541,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 20,
+        "w": 3,
+        "x": 18,
         "y": 6
       },
       "id": 180,
@@ -598,8 +598,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 22,
+        "w": 3,
+        "x": 21,
         "y": 6
       },
       "id": 181,
@@ -821,7 +821,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 9
       },
       "id": 177,
       "options": {
@@ -840,7 +840,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total[2m]) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total[$__rate_interval]) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -858,7 +858,7 @@
           "refId": "mem_usage"
         },
         {
-          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_bytes_total[2m])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_bytes_total[2m]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_bytes_total[$__rate_interval])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_bytes_total[$__rate_interval]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -867,7 +867,7 @@
           "refId": "net_throughput"
         },
         {
-          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_packets_total[2m])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_packets_total[2m]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_packets_total[$__rate_interval])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_packets_total[$__rate_interval]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -876,7 +876,7 @@
           "refId": "packets_rate"
         },
         {
-          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_errors_total[2m])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_errors_total[2m]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_errors_total[$__rate_interval])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_errors_total[$__rate_interval]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -885,7 +885,7 @@
           "refId": "net_errors"
         },
         {
-          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_drops_total[2m])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_drops_total[2m]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_drops_total[$__rate_interval])) + sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_drops_total[$__rate_interval]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -894,7 +894,7 @@
           "refId": "packets_drops"
         },
         {
-          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_read_requests_total[2m])) + sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_write_requests_total[2m]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_read_requests_total[$__rate_interval])) + sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_write_requests_total[$__rate_interval]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -903,7 +903,7 @@
           "refId": "disks_iops"
         },
         {
-          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_read_bytes_total[2m])) + sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_write_bytes_total[2m]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "(sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_read_bytes_total[$__rate_interval])) + sum by(juju_unit, domain) (rate(libvirt_domain_block_stats_write_bytes_total[$__rate_interval]))) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -965,7 +965,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "CPU time used by the domain, in seconds - rate over 1min",
+      "description": "CPU time used by the domain - rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1020,7 +1020,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 19
       },
       "id": 8,
       "options": {
@@ -1043,7 +1043,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total[2m]) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total[$__rate_interval]) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "{{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "A"
@@ -1059,7 +1059,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 28
       },
       "id": 10,
       "panels": [],
@@ -1132,7 +1132,7 @@
         "h": 8,
         "w": 9,
         "x": 0,
-        "y": 39
+        "y": 29
       },
       "id": 16,
       "options": {
@@ -1224,7 +1224,7 @@
         "h": 8,
         "w": 8,
         "x": 9,
-        "y": 39
+        "y": 29
       },
       "id": 12,
       "options": {
@@ -1347,7 +1347,7 @@
         "h": 8,
         "w": 7,
         "x": 17,
-        "y": 39
+        "y": 29
       },
       "id": 14,
       "options": {
@@ -1405,7 +1405,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 37
       },
       "id": 20,
       "panels": [],
@@ -1423,7 +1423,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Network traffic in bytes, rate over 1min, receive/transmit per instance, cumulative over all interfaces",
+      "description": "Network traffic in bytes, rate over time, receive/transmit per instance, cumulative over all interfaces",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1479,7 +1479,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 38
       },
       "id": 18,
       "options": {
@@ -1502,13 +1502,13 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_bytes_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_bytes_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "rx: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "A"
         },
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_bytes_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_bytes_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "tx: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "B"
@@ -1519,7 +1519,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Network traffic in packets, rate over 1min, receive/transmit per instance, cumulative over all interfaces",
+      "description": "Network traffic in packets, rate over time, receive/transmit per instance, cumulative over all interfaces",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1575,7 +1575,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 38
       },
       "id": 22,
       "options": {
@@ -1598,13 +1598,13 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_packets_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_packets_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "rx: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "A"
         },
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_packets_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_packets_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "tx: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "B"
@@ -1615,7 +1615,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Total network throughput rates per hypervisor, rate over 1min",
+      "description": "Total network throughput rates per hypervisor, rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1674,7 +1674,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 47
       },
       "id": 24,
       "options": {
@@ -1697,13 +1697,13 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_receive_bytes_total[2m]))",
+          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_receive_bytes_total[$__rate_interval]))",
           "interval": "",
           "legendFormat": "rx: {{juju_unit}}",
           "refId": "A"
         },
         {
-          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_transmit_bytes_total[2m]))",
+          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_transmit_bytes_total[$__rate_interval]))",
           "interval": "",
           "legendFormat": "tx: {{juju_unit}}",
           "refId": "B"
@@ -1714,7 +1714,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Total network throughput rates per hypervisor, rate over 1min",
+      "description": "Total network throughput rates per hypervisor, rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1770,7 +1770,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 47
       },
       "id": 25,
       "options": {
@@ -1793,13 +1793,13 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_receive_packets_total[2m]))",
+          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_receive_packets_total[$__rate_interval]))",
           "interval": "",
           "legendFormat": "rx: {{juju_unit}}",
           "refId": "A"
         },
         {
-          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_transmit_packets_total[2m]))",
+          "expr": "sum by(juju_unit) (rate(libvirt_domain_interface_stats_transmit_packets_total[$__rate_interval]))",
           "interval": "",
           "legendFormat": "tx: {{juju_unit}}",
           "refId": "B"
@@ -1810,7 +1810,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Instance errors and drops, transmit and receive. Rate over 1min",
+      "description": "Instance errors and drops, transmit and receive. Rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1866,7 +1866,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 55
       },
       "id": 33,
       "options": {
@@ -1889,25 +1889,25 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_errors_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_errors_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "rx err: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "A"
         },
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_errors_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_errors_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "tx err: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "B"
         },
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_drops_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_receive_drops_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "rx drop: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "C"
         },
         {
-          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_drops_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain) (rate(libvirt_domain_interface_stats_transmit_drops_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "tx drop: {{project_name}} | {{instance_name}} | {{uuid}}",
           "refId": "D"
@@ -1923,7 +1923,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 66
       },
       "id": 35,
       "panels": [],
@@ -1941,7 +1941,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Instance block dev read request rate over 1min",
+      "description": "Instance block dev read request rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1997,7 +1997,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 77
+        "y": 67
       },
       "id": 37,
       "options": {
@@ -2020,7 +2020,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_read_requests_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_read_requests_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "{{project_name}} | {{instance_name}} | {{uuid}} | {{target_device}}",
           "refId": "A"
@@ -2031,7 +2031,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Instance block dev write request rate over 1min",
+      "description": "Instance block dev write request rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2087,7 +2087,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 77
+        "y": 67
       },
       "id": 39,
       "options": {
@@ -2110,7 +2110,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_write_requests_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_write_requests_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "{{project_name}} | {{instance_name}} | {{uuid}} | {{target_device}}",
           "refId": "A"
@@ -2121,7 +2121,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Instance block device read bytes rate over 1min",
+      "description": "Instance block device read bytes rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2177,7 +2177,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 75
       },
       "id": 40,
       "options": {
@@ -2200,7 +2200,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_read_bytes_total[2m])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_read_bytes_total[$__rate_interval])) * on(juju_unit, domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "{{project_name}} | {{instance_name}} | {{uuid}} | {{target_device}}",
           "refId": "A"
@@ -2211,7 +2211,7 @@
     },
     {
       "datasource": "${prometheusds}",
-      "description": "Instance block device write bytes rate over 1min",
+      "description": "Instance block device write bytes rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2267,7 +2267,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 75
       },
       "id": 38,
       "options": {
@@ -2290,7 +2290,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_write_bytes_total[2m])) * on(domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
+          "expr": "sum by(juju_unit, domain, target_device) (rate(libvirt_domain_block_stats_write_bytes_total[$__rate_interval])) * on(domain) group_left(project_name, instance_name, uuid) libvirt_domain_info_meta{project_name=~\"$project\"}",
           "interval": "",
           "legendFormat": "{{project_name}} | {{instance_name}} | {{uuid}} | {{target_device}}",
           "refId": "A"

--- a/src/grafana_dashboards/openstack-exporter.json
+++ b/src/grafana_dashboards/openstack-exporter.json
@@ -1,46 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "https://github.com/openstack-exporter/openstack-exporter",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.1.4"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": "5.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -84,7 +42,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -160,7 +118,7 @@
     },
     {
       "columns": [],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -298,7 +256,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -381,7 +339,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -455,7 +413,7 @@
     },
     {
       "columns": [],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -615,7 +573,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -696,7 +654,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -771,7 +729,7 @@
     },
     {
       "columns": [],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -947,7 +905,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1038,7 +996,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1131,7 +1089,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1225,7 +1183,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1316,7 +1274,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1421,7 +1379,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1519,7 +1477,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1612,7 +1570,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1704,7 +1662,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${prometheusds}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1796,7 +1754,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${prometheusds}",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",


### PR DESCRIPTION
This includes fixes:

- 916716: Fix datasource for openstack dashboard | https://review.opendev.org/c/openstack/sunbeam-charms/+/916716
- 916851: Replace hardcoded intervals with $__rate_interval | https://review.opendev.org/c/openstack/sunbeam-charms/+/916851
- 916855: Fix grid positions for hypervisor dashboard | https://review.opendev.org/c/openstack/sunbeam-charms/+/916855

To test this PR, run:

```
make check-dashboard-updates
```

And verify all OK.