### PR TITLE
Sync grafana dashboards from upstream

### DIFF
--- a/scripts/sync-dashboards
+++ b/scripts/sync-dashboards
@@ -10,9 +10,9 @@ from urllib.request import urlretrieve
 BASE_URL = "https://opendev.org/openstack/sunbeam-charms/raw/branch/main/charms/openstack-exporter-k8s/src/grafana_dashboards/"
 BASE_LOCAL_PATH = "./src/grafana_dashboards/"
 DASHBOARDS = [
-    "hypervisor-openstack-exporter-dashboard.json",
-    "openstack-exporter.json",
-    "overview-openstack-exporter-dashboard.json",
+    "cloud.json",
+    "compute.json",
+    "service.json",
 ]
 
 

--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -76,7 +76,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# Openstack dashboard\n\n* filter by juju_model (for openstack models) if connected to multiple clouds\n* openstack data is cached, currently refreshed every 5 minutes\n* The VM creation / teardown graph doesn't show the values for the builders in scalingstacks because they happen a lot faster than our scrape interval\n* \"Free IPs\" are not owned by any tenant and available for allocation\n* \"Unused IPs\" are owned by a tenant but not currently associated with an instance",
+        "content": "# OpenStack Cloud Usage\n\n* filter by juju_model (for openstack models) if connected to multiple clouds",
         "mode": "markdown"
       },
       "pluginVersion": "9.2.1",
@@ -201,7 +201,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "count(group by(tenant) (openstack_nova_limits_instances_max))",
+          "expr": "count(group by(tenant_id) (openstack_nova_limits_instances_max))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -759,7 +759,7 @@
               }
             ]
           },
-          "unit": "decmbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -791,7 +791,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "sum(openstack_nova_memory_used_bytes{aggregates=~\"$aggregate\"}) / 1e+06",
+          "expr": "sum(openstack_nova_memory_used_bytes{aggregates=~\"$aggregate\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -821,7 +821,7 @@
               }
             ]
           },
-          "unit": "decmbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -853,7 +853,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "sum(openstack_nova_memory_available_bytes{aggregates=~\"$aggregate\"}) / 1e+06",
+          "expr": "sum(openstack_nova_memory_available_bytes{aggregates=~\"$aggregate\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -1038,7 +1038,7 @@
               }
             ]
           },
-          "unit": "decgbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1068,7 +1068,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "(sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"} / 1e+09)) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes) / 1e+09)",
+          "expr": "(sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes))",
           "intervalFactor": 2,
           "legendFormat": "{{aggregate}}",
           "refId": "A",
@@ -1372,7 +1372,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1402,7 +1402,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "sum by(hostname) (openstack_nova_memory_available_bytes) / 1e+09 - sum by(hostname) (openstack_nova_memory_used_bytes) / 1e+09",
+          "expr": "sum by(hostname) (openstack_nova_memory_available_bytes) - sum by(hostname) (openstack_nova_memory_used_bytes)",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -1412,7 +1412,7 @@
         }
       ],
       "timeFrom": "20m",
-      "title": "Free RAM GBs per host",
+      "title": "Free RAM per host",
       "transformations": [
         {
           "id": "reduce",
@@ -1451,7 +1451,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1480,7 +1480,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "sum by(hostname) (openstack_nova_local_storage_available_bytes) / 1e+09 - sum by(hostname) (openstack_nova_local_storage_used_bytes) / 1e+09",
+          "expr": "sum by(hostname) (openstack_nova_local_storage_available_bytes) - sum by(hostname) (openstack_nova_local_storage_used_bytes)",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -1490,7 +1490,7 @@
         }
       ],
       "timeFrom": "20m",
-      "title": "Free disk GBs per host",
+      "title": "Free disk per host",
       "transformations": [
         {
           "id": "reduce",
@@ -1700,7 +1700,7 @@
     ]
   },
   "timezone": "utc",
-  "title": "OpenStack Overview",
+  "title": "OpenStack Cloud Usage",
   "uid": "7d177394-f0b4-11ee-9495-9b832692810a",
   "version": 1,
   "weekStart": ""

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -421,7 +421,7 @@
               }
             ]
           },
-          "unit": "mbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -450,7 +450,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(openstack_nova_memory_used_bytes{hostname=~\"$hypervisor.*\"}) / 1000000",
+          "expr": "sum(openstack_nova_memory_used_bytes{hostname=~\"$hypervisor.*\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -478,7 +478,7 @@
               }
             ]
           },
-          "unit": "mbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -507,7 +507,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(openstack_nova_memory_available_bytes{hostname=~\"$hypervisor.*\"}) / 1000000",
+          "expr": "sum(openstack_nova_memory_available_bytes{hostname=~\"$hypervisor.*\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -535,7 +535,7 @@
               }
             ]
           },
-          "unit": "decgbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -564,7 +564,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / 1000000000",
+          "expr": "sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -592,7 +592,7 @@
               }
             ]
           },
-          "unit": "decgbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -621,7 +621,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) / 1000000000",
+          "expr": "sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -675,7 +675,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "decbytes"
+                "value": "bytes"
               },
               {
                 "id": "displayName",
@@ -1124,7 +1124,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1216,7 +1216,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1282,7 +1282,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": [
           {
@@ -2396,6 +2396,6 @@
     ]
   },
   "timezone": "utc",
-  "title": "OpenStack Hypervisor Overview",
+  "title": "OpenStack Compute Overview",
   "version": 1
 }

--- a/src/grafana_dashboards/service.json
+++ b/src/grafana_dashboards/service.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Openstack dashboard using the Openstack Exporter (https://github.com/openstack-exporter/openstack-exporter)",
+  "description": "OpenStack Service overview using the Openstack Exporter (https://github.com/openstack-exporter/openstack-exporter)",
   "editable": true,
   "gnetId": 9701,
   "graphTooltip": 0,
@@ -1890,7 +1890,7 @@
     ]
   },
   "timezone": "",
-  "title": "OpenStack Dashboard",
+  "title": "OpenStack Service Overview",
   "uid": "YZCsB1Qmz",
   "version": 20
 }


### PR DESCRIPTION
This includes the following patches:

- 917826: Rename grafana dashboards for openstack-exporter | https://review.opendev.org/c/openstack/sunbeam-charms/+/917826
- 917912: Standardise bytes units in dashboards | https://review.opendev.org/c/openstack/sunbeam-charms/+/917912
- 917917: Fix counting projects panel in cloud dashboard | https://review.opendev.org/c/openstack/sunbeam-charms/+/917917