### PR TITLE
Add link to website homepage

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -62,6 +62,8 @@ links:
   - https://github.com/canonical/openstack-exporter-operator/issues
   source:
   - https://github.com/canonical/openstack-exporter-operator
+  website:
+  - https://github.com/canonical/openstack-exporter-operator
 
 resources:
   openstack-exporter:


### PR DESCRIPTION
Hopefully this will populate the link to this repository on the charmhub page - the source and issues links seem to be ignored?