### PR TITLE
Using pre-release version of charming action

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.4.0
+        # Note(rgildein): Since this charm uses the metadata defined in charmcraft.yaml, we need to use the pre-release version that includes https://github.com/canonical/charming-actions/pull/132.
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Release charm to channel
         # Note(rgildein): Since this charm uses the metadata defined in charmcraft.yaml, we need to use the pre-release version that includes https://github.com/canonical/charming-actions/pull/132.
-        uses: canonical/charming-actions/upload-charm@2.5.0-rc
+        uses: canonical/charming-actions/release-charm@2.5.0-rc
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -24,3 +24,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          # Note(rgildein): The default is 20.04, but this charm has never been released for this base.
+          base-channel: 22.04


### PR DESCRIPTION
We need to use pre-release, since this charm is using metadata.yaml defined in charmcraft.yaml.