### PR TITLE
chore: apply new github bot for jira and gh sync and remove the old jira_gh sync action

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -17,6 +17,9 @@ settings:
   components:
     - openstack-exporter
 
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: SOLENG-46
+
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug
   label_mapping:

--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,3 +1,8 @@
+#
+# For more info about the settings, please refre to the github repository:
+# https://github.com/canonical/gh-jira-sync-bot
+#
+
 settings:
   # Jira project key to create the issue in
   jira_project_key: "SOLENG"
@@ -11,24 +16,6 @@ settings:
   # Component names are case-sensitive
   components:
     - openstack-exporter
-
-  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
-  # If not specified, all issues will be synchronized
-  # labels:
-  #   - bug
-  #   - enhancement
-
-  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
-  # add_gh_comment: false
-
-  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
-  # sync_description: true
-
-  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
-  # sync_comments: true
-
-  # (Optional) (Default: None) Parent Epic key to link the issue to
-  # epic_key: "MTC-296"
 
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug


### PR DESCRIPTION
Apply new GitHub bot for jira and gh sync, and optionally (if there's any) remove the old jira to gh sync action.