### PR TITLE
Set cache default option to True

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,7 +49,7 @@ config:
         Customizable based on the size of the OpenStack cluster.
         Format details: https://pkg.go.dev/time#ParseDuration
     cache:
-      default: false
+      default: true
       type: boolean
       description: |
         Enables the exporter cache globally. Refreshes at intervals of cache_ttl/2.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -50,8 +50,8 @@ class TestCharm:
                 "cloud": CLOUD_NAME,
                 "os-client-config": str(OS_CLIENT_CONFIG),
                 "web": {"listen-address": f":{config.get('port', 9180)}"},
-                "cache": config.get("cache", False),
-                "cache-ttl": config.get("cache_ttl", "300s"),
+                "cache": config["cache"],
+                "cache-ttl": config["cache_ttl"],
             }
         )
         self.harness.charm._write_cloud_config.assert_called_with(mock_expect_keystone_data)


### PR DESCRIPTION
Having the cache option set to True will make the exporter work out of the box. Right now if not changed, the time to scrape is bigger than 10 seconds and it fails.