### PR TITLE
Set cache default option to True

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,7 +49,7 @@ config:
         Customizable based on the size of the OpenStack cluster.
         Format details: https://pkg.go.dev/time#ParseDuration
     cache:
-      default: false
+      default: true
       type: boolean
       description: |
         Enables the exporter cache globally. Refreshes at intervals of cache_ttl/2.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -52,7 +52,7 @@ config:
       default: true
       type: boolean
       description: |
-        Enables the exporter cache globally. Refreshes at intervals of cache_ttl/2.
+        By default, enables the exporter cache globally. Refreshes at intervals of cache_ttl/2.
         If the cache is empty or expired, the response will be empty.
 
 

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -83,6 +83,8 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         new_value = "random_ca"  # bad ssl_ca (will be reset shortly)
         old_value = model.get_application_config(APP_NAME).get(key)
         model.set_application_config(APP_NAME, {key: new_value})
+        # Change cache to false to not get previous scrape results
+        model.set_application_config(APP_NAME, {"cache": "false"})
         model.block_until_all_units_idle()
 
         # Get snap config: os-client-config and verify it's applied
@@ -106,6 +108,10 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         command = "curl -q localhost:9180/metrics"
         results = model.run_on_leader(APP_NAME, command)
         self.assertEqual(int(results.get("Code", "-1")), 0)
+
+        # Enable cache again
+        model.set_application_config(APP_NAME, {"cache": "true"})
+        model.block_until_all_units_idle()
 
 
 class OpenstackExporterStatusTest(OpenstackExporterBaseTest):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -50,8 +50,8 @@ class TestCharm:
                 "cloud": CLOUD_NAME,
                 "os-client-config": str(OS_CLIENT_CONFIG),
                 "web": {"listen-address": f":{config.get('port', 9180)}"},
-                "cache": config.get("cache", False),
-                "cache-ttl": config.get("cache_ttl", "300s"),
+                "cache": config["cache"],
+                "cache-ttl": config["cache_ttl"],
             }
         )
         self.harness.charm._write_cloud_config.assert_called_with(mock_expect_keystone_data)


### PR DESCRIPTION
Having the cache option set to True will make the exporter work out of the box. Right now if not changed, the time to scrape is bigger than 10 seconds and it fails.