### PR TITLE
Change grafana-agent to use stable channel on functional tests

### DIFF
--- a/tests/integration/tests/bundles/jammy-yoga.yaml
+++ b/tests/integration/tests/bundles/jammy-yoga.yaml
@@ -8,7 +8,7 @@ applications:
     num_units: 1
   grafana-agent:
     charm: grafana-agent
-    channel: edge
+    channel: stable
   ceph-mon:
     charm: ceph-mon
     channel: quincy/stable


### PR DESCRIPTION
Now that grafana-agent has a stable release, it's better to change our workflow to use it to avoid the CI breaking on the edge channel.

E.g: canonical/grafana-agent-operator#165