### PR TITLE
Add extra-bindings for all OpenStack endpoint interface types

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,9 +28,9 @@ provides:
 # network spaces. Needed when APIs are not exposed in the same network as the one bound
 # to the credentials endpoint
 extra-bindings:
-  admin-interface:
-  public-interface:
-  internal-interface:
+  admin:
+  public:
+  internal:
 
 config:
   options:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,6 +24,14 @@ provides:
   cos-agent:
     interface: cos_agent
 
+# These bindings can be used to explicitly request interfaces in all the OpenStack
+# network spaces. Needed when APIs are not exposed in the same network as the one bound
+# to the credentials endpoint
+extra-bindings:
+  admin-interface:
+  public-interface:
+  internal-interface:
+
 config:
   options:
     port:
@@ -84,8 +92,3 @@ resources:
       and a user can provide a local snap to use instead.
 
       This override may be useful for testing or in environments with network restrictions.
-
-extra-bindings:
-  admin-interface:
-  public-interface:
-  internal-interface:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -84,3 +84,8 @@ resources:
       and a user can provide a local snap to use instead.
 
       This override may be useful for testing or in environments with network restrictions.
+
+extra-bindings:
+  admin-interface:
+  public-interface:
+  internal-interface:


### PR DESCRIPTION
Add extra-bindings to the charm metadata to allow users to request legs
in all OpenStack networks spaces. This may be necessary in case the
OpenStack API endpoints to be queried are not available on the same
network space as the one used by the credentials endpoint.

While the charm doesn't explicitly use the bindingsi - meaning that the
same result could be achieved with machine space contraints - having
these specified as application bindings is more explicit.

This is effectively the same solution used in the previous exporter
charm, see
https://git.launchpad.net/charm-prometheus-openstack-exporter/commit/?id=99692c082eadbf5195bb683e92a73428603efbc6

Closes #90
