### PR TITLE
Check to see if it's not using the upstream snap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops ~= 2.5
 pyyaml ~= 6.0
+pysquashfsimage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 ops ~= 2.5
 pyyaml ~= 6.0
-pysquashfsimage

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,14 +15,18 @@ from typing import Any
 import ops
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from charms.operator_libs_linux.v2.snap import SnapError
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
     WaitingStatus,
 )
 
-from service import SNAP_NAME, SnapResource, get_installed_snap_service, snap_install_or_refresh
+from service import (
+    SNAP_NAME,
+    SnapResource,
+    get_installed_snap_service,
+    snap_install_or_refresh,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -135,9 +139,10 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         try:
             resource = SnapResource(RESOURCE_NAME, self.model)
             snap_install_or_refresh(resource, self.model.config["snap_channel"])
-        except SnapError:
+        except Exception as e:
+            logging.error("Failed to install/refresh openstack-exporter snap: %s", e)
             self.model.unit.status = BlockedStatus(
-                "Failed to remove/install openstack-exporter snap"
+                "Failed to install/refresh openstack-exporter snap"
             )
 
     def _configure(self, _: ops.HookEvent) -> None:
@@ -188,23 +193,32 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """Handle collect unit status event (called after every event)."""
         if not self.model.relations.get("credentials"):
             event.add_status(BlockedStatus("Keystone is not related"))
+            return
 
         if not self._get_keystone_data():
             event.add_status(WaitingStatus("Waiting for credentials from keystone"))
+            return
 
         if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
+            return
+
+        resource = SnapResource(RESOURCE_NAME, self.model)
+        if resource and resource.snap_name != SNAP_NAME:
+            event.add_status(BlockedStatus(f"snap resource {resource.snap_name} is not valid."))
+            return
 
         snap_service = get_installed_snap_service(SNAP_NAME)
-
         if not snap_service.present:
             event.add_status(
                 BlockedStatus("snap service is not installed, please check snap service")
             )
-        elif not snap_service.is_active():
+            return
+        if not snap_service.is_active():
             event.add_status(
                 BlockedStatus("snap service is not running, please check snap service")
             )
+            return
 
         event.add_status(ActiveStatus())
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,7 @@ from ops.model import (
     WaitingStatus,
 )
 
-from service import SNAP_NAME, get_installed_snap_service, snap_install_or_refresh
+from service import SNAP_NAME, UPSTREAM_SNAP, get_installed_snap_service, snap_install_or_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -168,8 +168,11 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """
         self.install()
 
-        snap_service = get_installed_snap_service(SNAP_NAME)
+        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
+        if upstream_snap.present:
+            return
 
+        snap_service = get_installed_snap_service(SNAP_NAME)
         # if cos is not related then we should block and not run anything
         if not self.model.relations.get("cos-agent"):
             snap_service.stop()
@@ -213,6 +216,15 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
+
+        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
+
+        if upstream_snap.present:
+            event.add_status(
+                BlockedStatus(
+                    f"{UPSTREAM_SNAP} should not be used anymore. Please remove the snap resource."
+                )
+            )
 
         snap_service = get_installed_snap_service(SNAP_NAME)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,10 +219,13 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
 
+        # this is necessary when doing a charm upgrade coming from revision 27
         if upstream_snap.present:
             event.add_status(
                 BlockedStatus(
-                    f"{UPSTREAM_SNAP} should not be used anymore. Please remove the snap resource."
+                    f"{UPSTREAM_SNAP} should not be used anymore. "
+                    "Please add an empty file as resource. See more information in the docs: "
+                    "https://charmhub.io/openstack-exporter#known-issues"
                 )
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -223,8 +223,7 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if upstream_snap.present:
             event.add_status(
                 BlockedStatus(
-                    f"{UPSTREAM_SNAP} should not be used anymore. "
-                    "Please add an empty file as resource. See more information in the docs: "
+                    "Please add an empty file as resource. For more info see: "
                     "https://charmhub.io/openstack-exporter#known-issues"
                 )
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ OpenStack deployment.
 
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 import ops
 import yaml
@@ -19,10 +19,11 @@ from charms.operator_libs_linux.v2.snap import SnapError
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
+    ModelError,
     WaitingStatus,
 )
 
-from service import SNAP_NAME, SnapResource, get_installed_snap_service, snap_install_or_refresh
+from service import SNAP_NAME, get_installed_snap_service, snap_install_or_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -130,11 +131,29 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
                     return data
         return {}
 
+    def get_resource(self) -> Optional[str]:
+        """Return the path-to-resource or None if the resource is empty.
+
+        Fetch the charm's resource and check if the resource is an empty file
+        or not. If it's empty, return None. Otherwise, return the path to the
+        resource.
+        """
+        try:
+            snap_path = self.model.resources.fetch(RESOURCE_NAME).absolute()
+        except ModelError:
+            logger.debug("cannot fetch charm resource")
+            return None
+
+        if not os.path.getsize(snap_path) > 0:
+            logger.debug("resource is an empty file")
+            return None
+
+        return snap_path
+
     def install(self) -> None:
         """Install the necessary resources for the charm."""
         try:
-            resource = SnapResource(RESOURCE_NAME, self.model)
-            snap_install_or_refresh(resource, self.model.config["snap_channel"])
+            snap_install_or_refresh(self.get_resource(), self.model.config["snap_channel"])
         except SnapError:
             self.model.unit.status = BlockedStatus(
                 "Failed to remove/install openstack-exporter snap"

--- a/src/charm.py
+++ b/src/charm.py
@@ -223,7 +223,7 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if upstream_snap.present:
             event.add_status(
                 BlockedStatus(
-                    "Please add an empty file as resource. For more info see: "
+                    "golang-openstack-exporter detected. Please see: "
                     "https://charmhub.io/openstack-exporter#known-issues"
                 )
             )

--- a/src/service.py
+++ b/src/service.py
@@ -4,11 +4,16 @@ import os
 from logging import getLogger
 from typing import Any, Optional
 
+import yaml
 from charms.operator_libs_linux.v2 import snap
+from ops.model import Model, ModelError
+from PySquashfsImage import SquashFsImage
 
 logger = getLogger(__name__)
 
 SNAP_NAME = "charmed-openstack-exporter"
+# the upstream snap
+UPSTREAM_SNAP = "golang-openstack-exporter"
 
 
 class SnapService:
@@ -56,7 +61,52 @@ class SnapService:
         return self.snap_client.present
 
 
-def snap_install_or_refresh(resource: Optional[str], channel: str) -> None:
+class SnapResource:
+    """A class representing the snap resource."""
+
+    def __init__(self, name: str, model: Model) -> None:
+        """Initialize the class."""
+        self.name = name
+        self.model = model
+
+    @property
+    def path(self) -> Optional[str]:
+        """Get the path of the resource.
+
+        If cannot fetch the resource it returns None.
+        """
+        try:
+            return self.model.resources.fetch(self.name).absolute()
+        except ModelError:
+            logger.debug("cannot fetch charm resource")
+            return None
+
+    @property
+    def size(self) -> Optional[int]:
+        """Get the snap size."""
+        return os.path.getsize(self.path) if self.path else None
+
+    @property
+    def snap_name(self) -> Optional[str]:
+        """Get the snap name from the resource passed.
+
+        Raise exception if not able to get the snap name
+        """
+        if self.size is None or self.path is None:
+            return None
+
+        try:
+            with SquashFsImage.from_file(self.path) as image:
+                # on snap files when unsquashfs it's possible to find the snap.yaml file that
+                # will have the snap name
+                snap_file = [file for file in image if "snap.yaml" == file.name][0].read_text()
+                return yaml.safe_load(snap_file)["name"]
+        except Exception as e:
+            logger.error("Failed to get the snap name from the resource: %s", self.path)
+            raise snap.SnapError("") from e
+
+
+def snap_install_or_refresh(resource: SnapResource, channel: str) -> None:
     """Install or refresh the snap.
 
     Before installing the snap, it will try to remove the upstream snap that could be installed on
@@ -69,10 +119,10 @@ def snap_install_or_refresh(resource: Optional[str], channel: str) -> None:
     """
     remove_upstream_snap()
     try:
-        if resource:
-            logger.debug("installing %s from resource.", SNAP_NAME)
+        if resource.size and resource.snap_name != UPSTREAM_SNAP:
+            logger.info("installing %s from resource.", resource.snap_name)
             # installing from a resource if installed from snap store previously is not problematic
-            snap.install_local(resource, dangerous=True)
+            snap.install_local(resource.path, dangerous=True)
         else:
             # installing from snap store if previously installed from resource is problematic, so
             # it's necessary to remove it first
@@ -93,9 +143,9 @@ def remove_upstream_snap() -> None:
     Raises an exception on error.
     """
     try:
-        snap.remove(["golang-openstack-exporter"])
+        snap.remove([UPSTREAM_SNAP])
     except snap.SnapError as e:
-        logger.error("failed to remove golang-openstack-exporter snap: %s", str(e))
+        logger.error(f"failed to remove {UPSTREAM_SNAP} snap: %s", str(e))
         raise e
 
 

--- a/src/service.py
+++ b/src/service.py
@@ -9,6 +9,7 @@ from charms.operator_libs_linux.v2 import snap
 logger = getLogger(__name__)
 
 SNAP_NAME = "charmed-openstack-exporter"
+UPSTREAM_SNAP = "golang-openstack-exporter"
 
 
 class SnapService:
@@ -93,9 +94,9 @@ def remove_upstream_snap() -> None:
     Raises an exception on error.
     """
     try:
-        snap.remove(["golang-openstack-exporter"])
+        snap.remove([UPSTREAM_SNAP])
     except snap.SnapError as e:
-        logger.error("failed to remove golang-openstack-exporter snap: %s", str(e))
+        logger.error("failed to remove %s snap: %s", UPSTREAM_SNAP, str(e))
         raise e
 
 

--- a/src/service.py
+++ b/src/service.py
@@ -69,13 +69,6 @@ class SnapResource:
         self.name = name
         self.model = model
 
-    def __bool__(self) -> bool:
-        """Boolean magic method for SnapResource.
-
-        Returns True if it has a name, False otherwise.
-        """
-        return bool(self.snap_name)
-
     @property
     def path(self) -> Optional[str]:
         """Get the path of the resource.
@@ -125,27 +118,23 @@ def snap_install_or_refresh(resource: SnapResource, channel: str) -> None:
     Raises an exception on error.
     """
     remove_upstream_snap()
-
-    if not resource:
-        # installing from snap store if previously installed from resource is problematic, so
-        # it's necessary to remove it first
-        remove_snap_as_resource()
-        logger.debug("installing %s from snapcraft store", SNAP_NAME)
-        snap.add(SNAP_NAME, channel=channel)
-    elif resource.snap_name == SNAP_NAME:
-        logger.info("installing %s from resource.", resource.snap_name)
-        # installing from a resource if installed from snap store previously is not problematic
-        snap.install_local(resource.path, dangerous=True)
+    try:
+        if resource.size and resource.snap_name != UPSTREAM_SNAP:
+            logger.info("installing %s from resource.", resource.snap_name)
+            # installing from a resource if installed from snap store previously is not problematic
+            snap.install_local(resource.path, dangerous=True)
+        else:
+            # installing from snap store if previously installed from resource is problematic, so
+            # it's necessary to remove it first
+            remove_snap_as_resource()
+            logger.debug("installing %s from snapcraft store", SNAP_NAME)
+            snap.add(SNAP_NAME, channel=channel)
+    except snap.SnapError as e:
+        logger.error("failed to install snap: %s", str(e))
+        raise e
     else:
-        logger.warning("%s is not a valid resource.", resource.snap_name)
-        logger.warning(
-            "Please remove the current resource to install from snap store or pass a "
-            "charmed-openstack-exporter snap file."
-        )
-        return
-
-    logger.info("installed %s snap.", SNAP_NAME)
-    workaround_bug_268()
+        logger.info("installed %s snap.", SNAP_NAME)
+        workaround_bug_268()
 
 
 def remove_upstream_snap() -> None:

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -3,7 +3,6 @@
 #
 # See LICENSE file for licensing details.
 
-import json
 import logging
 import subprocess
 import tempfile
@@ -14,7 +13,6 @@ import yaml
 from zaza import model
 
 from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME
-from service import UPSTREAM_SNAP
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +85,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
 
     def test_configure_snap_channel(self):
         """Test changing the snap channel."""
-        snap_info_before = get_snap_info(SNAP_NAME)
+        snap_info_before = get_snap_exporter_info()
         self.assertEqual(snap_info_before["channel"], "latest/stable")
 
         # Change snap channel
@@ -95,7 +93,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         model.set_application_config(APP_NAME, {"snap_channel": new_channel})
         model.block_until_all_units_idle()
 
-        snap_info_after = get_snap_info(SNAP_NAME)
+        snap_info_after = get_snap_exporter_info()
         self.assertEqual(snap_info_after["channel"], new_channel)
 
         model.reset_application_config(APP_NAME, ["snap_channel"])
@@ -107,7 +105,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         by the user changing the snap channel charm configuration.
         """
         # snap from snapstore won't have "x" in the revision
-        snap_info_before = get_snap_info(SNAP_NAME)
+        snap_info_before = get_snap_exporter_info()
         self.assertNotIn("x", snap_info_before["revision"])
 
         # juju cannot access resources at /tmp, so we create a tmp folder at the current directory
@@ -121,7 +119,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             model.block_until_all_units_idle()
 
             # local installed snaps will have "x" in the revision
-            snap_info_resource = get_snap_info(SNAP_NAME)
+            snap_info_resource = get_snap_exporter_info()
             self.assertIn("x", snap_info_resource["revision"])
 
             # changing channel won't affect the snap installed as resource
@@ -129,7 +127,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             new_channel = "latest/beta"
             model.set_application_config(APP_NAME, {"snap_channel": new_channel})
             model.block_until_all_units_idle()
-            channel_after = get_snap_info(SNAP_NAME)["channel"]
+            channel_after = get_snap_exporter_info()["channel"]
             self.assertNotEqual(channel_after, new_channel)
             self.assertEqual(channel_after, snap_info_resource["channel"])
 
@@ -140,32 +138,11 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             model.attach_resource(APP_NAME, "openstack-exporter", str(temp_file_path))
             model.block_until_all_units_idle()
 
-            snap_info_after = get_snap_info(SNAP_NAME)
+            snap_info_after = get_snap_exporter_info()
             self.assertNotIn("x", snap_info_after["revision"])
             self.assertEqual(snap_info_after["channel"], new_channel)
 
             model.reset_application_config(APP_NAME, ["snap_channel"])
-
-    def test_upstream_exporter_as_resource(self):
-        """Test that using the upstream golang as resource won't be installed."""
-        # snap from snapstore won't have "x" in the revision
-        snap_info_before = get_snap_info(SNAP_NAME)
-        self.assertNotIn("x", snap_info_before["revision"])
-
-        # juju cannot access resources at /tmp, so we create a tmp folder at the current directory
-        with tempfile.TemporaryDirectory(dir="./") as tmpdir:
-            tmp_path = Path(tmpdir)
-            download_cmd = f"snap download --target-directory={tmpdir} {UPSTREAM_SNAP}"
-            subprocess.run(download_cmd.split(), check=False)
-
-            resource_file = [file for file in tmp_path.iterdir() if ".snap" in file.name][0]
-            model.attach_resource(APP_NAME, "openstack-exporter", str(resource_file))
-            model.block_until_all_units_idle()
-
-            snaps = [snap["name"] for snap in get_snaps_installed()]
-            breakpoint()
-            self.assertIn(SNAP_NAME, snaps)
-            self.assertNotIn(UPSTREAM_SNAP, snaps)
 
     def test_configure_ssl_ca(self):
         """Test changing the ssl_ca."""
@@ -280,13 +257,17 @@ class OpenstackExporterStatusTest(OpenstackExporterBaseTest):
         self.assertEqual(self.leader_unit.workload_status_message, "")
 
 
-def get_snaps_installed() -> dict[str, str]:
-    """Get the snaps installed in the leader unit."""
-    cmd = "curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps"
-    return json.loads(model.run_on_leader(APP_NAME, cmd).get("Stdout", ""))["result"]
+def get_snap_exporter_info() -> dict[str, str]:
+    """Get the openstack exporter snap information.
 
-
-def get_snap_info(snap_name: str) -> list[dict[str, str]]:
-    """Get the snap information."""
-    snaps = get_snaps_installed()
-    return [snap for snap in snaps if snap["name"] == snap_name][0]
+    The snap list expected format as input is:
+    Name                        Version            Rev    Tracking       Publisher   Notes
+    charmed-openstack-exporter  1.7.0-26-g3be9ddb  4      latest/stable  canonical✓  -
+    """
+    results = model.run_on_leader(APP_NAME, f"snap list {SNAP_NAME}").get("Stdout", "").strip()
+    snap_info = results.splitlines()[1].split()
+    return {
+        "version": snap_info[VERSION_COLUMN],
+        "revision": snap_info[REVISION_COLUMN],
+        "channel": snap_info[CHANNEL_COLUMN],
+    }

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -276,8 +276,7 @@ class OpenstackExporterStatusTest(OpenstackExporterBaseTest):
             snaps_installed = [snap["name"] for snap in get_snaps_installed()]
             self.assertIn(UPSTREAM_SNAP, snaps_installed)
             expected_msg = (
-                f"{UPSTREAM_SNAP} should not be used anymore. "
-                "Please add an empty file as resource. See more information in the docs: "
+                "Please add an empty file as resource. For more info see: "
                 "https://charmhub.io/openstack-exporter#known-issues"
             )
             self.assertEqual(self.leader_unit.workload_status_message, expected_msg)

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -147,7 +147,11 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             model.reset_application_config(APP_NAME, ["snap_channel"])
 
     def test_upstream_exporter_as_resource(self):
-        """Test using the upstream golang as resource won't be installed and block the unit."""
+        """Test that using the upstream golang as resource won't be installed."""
+        # snap from snapstore won't have "x" in the revision
+        snap_info_before = get_snap_info(SNAP_NAME)
+        self.assertNotIn("x", snap_info_before["revision"])
+
         # juju cannot access resources at /tmp, so we create a tmp folder at the current directory
         with tempfile.TemporaryDirectory(dir="./") as tmpdir:
             tmp_path = Path(tmpdir)
@@ -156,22 +160,12 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
 
             resource_file = [file for file in tmp_path.iterdir() if ".snap" in file.name][0]
             model.attach_resource(APP_NAME, "openstack-exporter", str(resource_file))
-            model.block_until_unit_wl_status(
-                self.leader_unit_entity_id, "blocked", timeout=STATUS_TIMEOUT
-            )
-            self.assertEqual(
-                self.leader_unit.workload_status_message,
-                f"snap resource {UPSTREAM_SNAP} is not valid.",
-            )
+            model.block_until_all_units_idle()
 
             snaps = [snap["name"] for snap in get_snaps_installed()]
+            breakpoint()
+            self.assertIn(SNAP_NAME, snaps)
             self.assertNotIn(UPSTREAM_SNAP, snaps)
-
-            # passing an empty file will unblock the unit
-            temp_file_path = Path(tmpdir) / f"{SNAP_NAME}.snap"
-            temp_file_path.touch()
-            model.attach_resource(APP_NAME, "openstack-exporter", str(temp_file_path))
-            model.block_until_all_units_idle()
 
     def test_configure_ssl_ca(self):
         """Test changing the ssl_ca."""

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -3,6 +3,7 @@
 #
 # See LICENSE file for licensing details.
 
+import json
 import logging
 import subprocess
 import tempfile
@@ -12,7 +13,7 @@ from pathlib import Path
 import yaml
 from zaza import model
 
-from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME
+from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME, UPSTREAM_SNAP
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
 
     def test_configure_snap_channel(self):
         """Test changing the snap channel."""
-        snap_info_before = get_snap_exporter_info()
+        snap_info_before = get_snap_info(SNAP_NAME)
         self.assertEqual(snap_info_before["channel"], "latest/stable")
 
         # Change snap channel
@@ -93,7 +94,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         model.set_application_config(APP_NAME, {"snap_channel": new_channel})
         model.block_until_all_units_idle()
 
-        snap_info_after = get_snap_exporter_info()
+        snap_info_after = get_snap_info(SNAP_NAME)
         self.assertEqual(snap_info_after["channel"], new_channel)
 
         model.reset_application_config(APP_NAME, ["snap_channel"])
@@ -105,7 +106,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         by the user changing the snap channel charm configuration.
         """
         # snap from snapstore won't have "x" in the revision
-        snap_info_before = get_snap_exporter_info()
+        snap_info_before = get_snap_info(SNAP_NAME)
         self.assertNotIn("x", snap_info_before["revision"])
 
         # juju cannot access resources at /tmp, so we create a tmp folder at the current directory
@@ -119,7 +120,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             model.block_until_all_units_idle()
 
             # local installed snaps will have "x" in the revision
-            snap_info_resource = get_snap_exporter_info()
+            snap_info_resource = get_snap_info(SNAP_NAME)
             self.assertIn("x", snap_info_resource["revision"])
 
             # changing channel won't affect the snap installed as resource
@@ -127,7 +128,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             new_channel = "latest/beta"
             model.set_application_config(APP_NAME, {"snap_channel": new_channel})
             model.block_until_all_units_idle()
-            channel_after = get_snap_exporter_info()["channel"]
+            channel_after = get_snap_info(SNAP_NAME)["channel"]
             self.assertNotEqual(channel_after, new_channel)
             self.assertEqual(channel_after, snap_info_resource["channel"])
 
@@ -138,7 +139,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
             model.attach_resource(APP_NAME, "openstack-exporter", str(temp_file_path))
             model.block_until_all_units_idle()
 
-            snap_info_after = get_snap_exporter_info()
+            snap_info_after = get_snap_info(SNAP_NAME)
             self.assertNotIn("x", snap_info_after["revision"])
             self.assertEqual(snap_info_after["channel"], new_channel)
 
@@ -256,18 +257,45 @@ class OpenstackExporterStatusTest(OpenstackExporterBaseTest):
         )
         self.assertEqual(self.leader_unit.workload_status_message, "")
 
+    def test_upstream_exporter_as_resource(self):
+        """Test using the upstream golang as resource will block the unit."""
+        # juju cannot access resources at /tmp, so we create a tmp folder at the current directory
+        with tempfile.TemporaryDirectory(dir="./") as tmpdir:
+            tmp_path = Path(tmpdir)
+            download_cmd = (
+                f"wget -q -P {tmpdir} https://github.com/canonical/openstack-exporter-operator/"
+                "releases/download/rev2/golang-openstack-exporter_amd64.snap"
+            )
+            subprocess.run(download_cmd.split(), check=False)
 
-def get_snap_exporter_info() -> dict[str, str]:
-    """Get the openstack exporter snap information.
+            resource_file = tmp_path / "golang-openstack-exporter_amd64.snap"
+            model.attach_resource(APP_NAME, "openstack-exporter", str(resource_file))
+            model.block_until_unit_wl_status(
+                self.leader_unit_entity_id, "blocked", timeout=STATUS_TIMEOUT
+            )
+            snaps_installed = [snap["name"] for snap in get_snaps_installed()]
+            self.assertIn(UPSTREAM_SNAP, snaps_installed)
+            expected_msg = (
+                f"{UPSTREAM_SNAP} should not be used anymore. " "Please remove the snap resource."
+            )
+            self.assertEqual(self.leader_unit.workload_status_message, expected_msg)
 
-    The snap list expected format as input is:
-    Name                        Version            Rev    Tracking       Publisher   Notes
-    charmed-openstack-exporter  1.7.0-26-g3be9ddb  4      latest/stable  canonical✓  -
-    """
-    results = model.run_on_leader(APP_NAME, f"snap list {SNAP_NAME}").get("Stdout", "").strip()
-    snap_info = results.splitlines()[1].split()
-    return {
-        "version": snap_info[VERSION_COLUMN],
-        "revision": snap_info[REVISION_COLUMN],
-        "channel": snap_info[CHANNEL_COLUMN],
-    }
+            # passing an empty file will unblock the unit
+            temp_file_path = Path(tmpdir) / f"{SNAP_NAME}.snap"
+            temp_file_path.touch()
+            model.attach_resource(APP_NAME, "openstack-exporter", str(temp_file_path))
+            model.block_until_unit_wl_status(
+                self.leader_unit_entity_id, "active", timeout=STATUS_TIMEOUT
+            )
+
+
+def get_snaps_installed() -> dict[str, str]:
+    """Get the snaps installed in the leader unit."""
+    cmd = "curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps"
+    return json.loads(model.run_on_leader(APP_NAME, cmd).get("Stdout", ""))["result"]
+
+
+def get_snap_info(snap_name: str) -> list[dict[str, str]]:
+    """Get the snap information."""
+    snaps = get_snaps_installed()
+    return [snap for snap in snaps if snap["name"] == snap_name][0]

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -276,7 +276,7 @@ class OpenstackExporterStatusTest(OpenstackExporterBaseTest):
             snaps_installed = [snap["name"] for snap in get_snaps_installed()]
             self.assertIn(UPSTREAM_SNAP, snaps_installed)
             expected_msg = (
-                "Please add an empty file as resource. For more info see: "
+                "golang-openstack-exporter detected. Please see: "
                 "https://charmhub.io/openstack-exporter#known-issues"
             )
             self.assertEqual(self.leader_unit.workload_status_message, expected_msg)

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -276,7 +276,9 @@ class OpenstackExporterStatusTest(OpenstackExporterBaseTest):
             snaps_installed = [snap["name"] for snap in get_snaps_installed()]
             self.assertIn(UPSTREAM_SNAP, snaps_installed)
             expected_msg = (
-                f"{UPSTREAM_SNAP} should not be used anymore. " "Please remove the snap resource."
+                f"{UPSTREAM_SNAP} should not be used anymore. "
+                "Please add an empty file as resource. See more information in the docs: "
+                "https://charmhub.io/openstack-exporter#known-issues"
             )
             self.assertEqual(self.leader_unit.workload_status_message, expected_msg)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -81,15 +81,19 @@ class TestCharm:
         self.harness.update_config({"snap_channel": "latest/edge"})
         mock_install.assert_called_once()
 
-    @mock.patch("charm.OpenstackExporterOperatorCharm.get_resource", return_value="")
+    @mock.patch("charm.SnapResource")
     @mock.patch("charm.snap_install_or_refresh")
-    def test_install_snap(self, mock_install, _):
+    def test_install(self, mock_install, mock_resource):
+        """Test install method."""
+        resource = mock.MagicMock()
+        mock_resource.return_value = resource
         self.harness.begin()
         self.harness.charm.on.install.emit()
-        mock_install.assert_called_with("", "latest/stable")
+        mock_install.assert_called_with(resource, "latest/stable")
 
     @mock.patch("charm.snap_install_or_refresh")
-    def test_install_snap_error(self, mock_install):
+    def test_install_error(self, mock_install):
+        """Test install method when install raises exception."""
         mock_install.side_effect = SnapError("My Error")
         self.harness.begin()
         self.harness.charm.on.install.emit()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -81,19 +81,15 @@ class TestCharm:
         self.harness.update_config({"snap_channel": "latest/edge"})
         mock_install.assert_called_once()
 
-    @mock.patch("charm.SnapResource")
+    @mock.patch("charm.OpenstackExporterOperatorCharm.get_resource", return_value="")
     @mock.patch("charm.snap_install_or_refresh")
-    def test_install(self, mock_install, mock_resource):
-        """Test install method."""
-        resource = mock.MagicMock()
-        mock_resource.return_value = resource
+    def test_install_snap(self, mock_install, _):
         self.harness.begin()
         self.harness.charm.on.install.emit()
-        mock_install.assert_called_with(resource, "latest/stable")
+        mock_install.assert_called_with("", "latest/stable")
 
     @mock.patch("charm.snap_install_or_refresh")
-    def test_install_error(self, mock_install):
-        """Test install method when install raises exception."""
+    def test_install_snap_error(self, mock_install):
         mock_install.side_effect = SnapError("My Error")
         self.harness.begin()
         self.harness.charm.on.install.emit()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,8 +15,9 @@ from charm import (
     OS_CLIENT_CONFIG,
     SNAP_NAME,
     OpenstackExporterOperatorCharm,
+    SnapError,
 )
-from service import SnapResource, SnapService
+from service import SnapService
 
 
 class TestCharm:
@@ -84,18 +85,17 @@ class TestCharm:
     @mock.patch("charm.snap_install_or_refresh")
     def test_install(self, mock_install, mock_resource):
         """Test install method."""
-        resource = mock.MagicMock(spec_set=SnapResource)
+        resource = mock.MagicMock()
         mock_resource.return_value = resource
         self.harness.begin()
         self.harness.charm.on.install.emit()
         mock_install.assert_called_with(resource, "latest/stable")
 
     @mock.patch("charm.snap_install_or_refresh")
-    def test_install_snap_error(self, mock_install):
-        """Test install method when install raises exception from the snap lib."""
-        mock_install.side_effect = Exception("My Error")
+    def test_install_error(self, mock_install):
+        """Test install method when install raises exception."""
+        mock_install.side_effect = SnapError("My Error")
         self.harness.begin()
         self.harness.charm.on.install.emit()
-        assert self.harness.charm.unit.status == BlockedStatus(
-            "Failed to install/refresh openstack-exporter snap"
-        )
+        expected_msg = "Failed to remove/install openstack-exporter snap"
+        assert self.harness.charm.unit.status == BlockedStatus(expected_msg)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -42,9 +42,9 @@ def test_snap_install_or_refresh_with_resource_from_upstream(
     service.snap_install_or_refresh(resource, "my-channel")
     mock_remove_upstream.assert_called_once()
     mock_snap.install_local.assert_not_called()
-    mock_workaround.assert_not_called()
-    mock_remove_resource.assert_not_called()
-    mock_snap.add.assert_not_called()
+    mock_workaround.assert_called_once()
+    mock_remove_resource.assert_called_once()
+    mock_snap.add.assert_called_once_with(service.SNAP_NAME, channel="my-channel")
 
 
 @mock.patch("service.remove_upstream_snap")
@@ -58,7 +58,6 @@ def test_snap_install_or_refresh_snap_store(
     resource = mock.MagicMock(spec_set=service.SnapResource)
     resource.size = 0
     resource.snap_name = None
-    resource.__bool__.return_value = False
     service.snap_install_or_refresh(resource, "my-channel")
     resource.path = "/var/resources/openstack-exporter.snap"
     mock_remove_upstream.assert_called_once()
@@ -73,9 +72,6 @@ def test_snap_install_or_refresh_snap_store(
 def test_snap_install_or_refresh_exception_raises(mock_snap, mock_workaround):
     """Test that when an exception happens, it will raise an exception to the caller."""
     resource = mock.MagicMock(spec_set=service.SnapResource)
-    resource.size = 128
-    resource.snap_name = service.SNAP_NAME
-    resource.__bool__.return_value = True
     mock_snap.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):
         service.snap_install_or_refresh(resource, "my-channel")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -16,11 +16,35 @@ def test_snap_install_or_refresh_with_resource(
     mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream
 ):
     """Test snap installation with resource."""
-    service.snap_install_or_refresh("my-resource", "latest/stable")
+    resource = mock.MagicMock(spec_set=service.SnapResource)
+    resource.size = 128
+    resource.snap_name = service.SNAP_NAME
+    resource.path = path = "/var/resources/openstack-exporter.snap"
+    service.snap_install_or_refresh(resource, "latest/stable")
     mock_remove_upstream.assert_called_once()
-    mock_snap.install_local.assert_called_once_with("my-resource", dangerous=True)
+    mock_snap.install_local.assert_called_once_with(path, dangerous=True)
     mock_workaround.assert_called_once()
     mock_remove_resource.assert_not_called()
+
+
+@mock.patch("service.remove_upstream_snap")
+@mock.patch("service.remove_snap_as_resource")
+@mock.patch("service.workaround_bug_268")
+@mock.patch("service.snap")
+def test_snap_install_or_refresh_with_resource_from_upstream(
+    mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream
+):
+    """Test snap installation with resource using the upstream."""
+    resource = mock.MagicMock(spec_set=service.SnapResource)
+    resource.size = 128
+    resource.snap_name = service.UPSTREAM_SNAP
+    resource.path = "/var/resources/openstack-exporter.snap"
+    service.snap_install_or_refresh(resource, "my-channel")
+    mock_remove_upstream.assert_called_once()
+    mock_snap.install_local.assert_not_called()
+    mock_workaround.assert_called_once()
+    mock_remove_resource.assert_called_once()
+    mock_snap.add.assert_called_once_with(service.SNAP_NAME, channel="my-channel")
 
 
 @mock.patch("service.remove_upstream_snap")
@@ -30,8 +54,12 @@ def test_snap_install_or_refresh_with_resource(
 def test_snap_install_or_refresh_snap_store(
     mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream
 ):
-    """Test snap installation using the snap store."""
-    service.snap_install_or_refresh("", "my-channel")
+    """Test snap installation using the snap store by having an empty resource."""
+    resource = mock.MagicMock(spec_set=service.SnapResource)
+    resource.size = 0
+    resource.snap_name = None
+    service.snap_install_or_refresh(resource, "my-channel")
+    resource.path = "/var/resources/openstack-exporter.snap"
     mock_remove_upstream.assert_called_once()
     mock_snap.install_local.assert_not_called()
     mock_snap.add.assert_called_once_with(service.SNAP_NAME, channel="my-channel")
@@ -43,9 +71,10 @@ def test_snap_install_or_refresh_snap_store(
 @mock.patch("service.snap.add")
 def test_snap_install_or_refresh_exception_raises(mock_snap, mock_workaround):
     """Test that when an exception happens, it will raise an exception to the caller."""
+    resource = mock.MagicMock(spec_set=service.SnapResource)
     mock_snap.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):
-        service.snap_install_or_refresh("", "my-channel")
+        service.snap_install_or_refresh(resource, "my-channel")
     mock_workaround.assert_not_called()
 
 
@@ -116,3 +145,67 @@ def test_remove_snap_as_resource_exception(mock_snap_remove, mock_snap_cache):
     mock_snap_remove.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):
         service.remove_snap_as_resource()
+
+
+@mock.patch("service.SquashFsImage.from_file")
+@mock.patch("service.yaml.safe_load")
+@mock.patch("service.os.path.getsize")
+def test_snap_resource(mock_size, mock_yaml, mock_image):
+    """Test the SnapResource class."""
+    model = mock.MagicMock(spec_set=service.Model)
+    mocked_resource = mock.MagicMock()
+    mocked_resource.absolute.return_value = path = "/var/resources/openstack-exporter.snap"
+    mock_size.return_value = size = 128
+    model.resources.fetch.return_value = mocked_resource
+    mock_file = mock.MagicMock()
+    mock_file.name = "snap.yaml"
+    mock_image.return_value.__enter__.return_value = [mock_file]
+    mock_image.__exit__.return_value = None
+
+    mock_yaml.return_value = {
+        "name": "golang-openstack-exporter",
+        "version": "latest",
+        "summary": "OpenStack Exporter for Prometheus",
+        "description": "The OpenStack exporter, exports Prometheus metrics",
+        "apps": {
+            "openstack-exporter": {
+                "command": "bin/openstack-exporter",
+                "plugs": ["home", "network", "network-bind"],
+                "command-chain": ["snap/command-chain/snapcraft-runner"],
+            }
+        },
+        "architectures": ["amd64"],
+        "assumes": ["command-chain"],
+        "base": "core18",
+        "confinement": "strict",
+        "grade": "devel",
+    }
+
+    resource = service.SnapResource("openstack-exporter", model)
+
+    assert resource.path == path
+    assert resource.size == size
+    assert resource.snap_name == "golang-openstack-exporter"
+
+
+def test_snap_resource_empty_path():
+    """Test snap resource when the path is empty."""
+    model = mock.MagicMock(spec_set=service.Model)
+    model.resources.fetch.side_effect = service.ModelError("Failed to fetch")
+
+    resource = service.SnapResource("openstack-exporter", model)
+    assert resource.path is None
+    assert resource.size is None
+    assert resource.snap_name is None
+
+
+@mock.patch("service.SquashFsImage.from_file")
+def test_snap_resource_err(mock_image):
+    """Test SnapResource fails to get the snap name."""
+    model = mock.MagicMock(spec_set=service.Model)
+    mock_image.side_effect = Exception("File not found")
+
+    resource = service.SnapResource("openstack-exporter", model)
+
+    with pytest.raises(service.snap.SnapError):
+        _ = resource.snap_name

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -16,35 +16,11 @@ def test_snap_install_or_refresh_with_resource(
     mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream
 ):
     """Test snap installation with resource."""
-    resource = mock.MagicMock(spec_set=service.SnapResource)
-    resource.size = 128
-    resource.snap_name = service.SNAP_NAME
-    resource.path = path = "/var/resources/openstack-exporter.snap"
-    service.snap_install_or_refresh(resource, "latest/stable")
+    service.snap_install_or_refresh("my-resource", "latest/stable")
     mock_remove_upstream.assert_called_once()
-    mock_snap.install_local.assert_called_once_with(path, dangerous=True)
+    mock_snap.install_local.assert_called_once_with("my-resource", dangerous=True)
     mock_workaround.assert_called_once()
     mock_remove_resource.assert_not_called()
-
-
-@mock.patch("service.remove_upstream_snap")
-@mock.patch("service.remove_snap_as_resource")
-@mock.patch("service.workaround_bug_268")
-@mock.patch("service.snap")
-def test_snap_install_or_refresh_with_resource_from_upstream(
-    mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream
-):
-    """Test snap installation with resource using the upstream."""
-    resource = mock.MagicMock(spec_set=service.SnapResource)
-    resource.size = 128
-    resource.snap_name = service.UPSTREAM_SNAP
-    resource.path = "/var/resources/openstack-exporter.snap"
-    service.snap_install_or_refresh(resource, "my-channel")
-    mock_remove_upstream.assert_called_once()
-    mock_snap.install_local.assert_not_called()
-    mock_workaround.assert_called_once()
-    mock_remove_resource.assert_called_once()
-    mock_snap.add.assert_called_once_with(service.SNAP_NAME, channel="my-channel")
 
 
 @mock.patch("service.remove_upstream_snap")
@@ -54,12 +30,8 @@ def test_snap_install_or_refresh_with_resource_from_upstream(
 def test_snap_install_or_refresh_snap_store(
     mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream
 ):
-    """Test snap installation using the snap store by having an empty resource."""
-    resource = mock.MagicMock(spec_set=service.SnapResource)
-    resource.size = 0
-    resource.snap_name = None
-    service.snap_install_or_refresh(resource, "my-channel")
-    resource.path = "/var/resources/openstack-exporter.snap"
+    """Test snap installation using the snap store."""
+    service.snap_install_or_refresh("", "my-channel")
     mock_remove_upstream.assert_called_once()
     mock_snap.install_local.assert_not_called()
     mock_snap.add.assert_called_once_with(service.SNAP_NAME, channel="my-channel")
@@ -71,10 +43,9 @@ def test_snap_install_or_refresh_snap_store(
 @mock.patch("service.snap.add")
 def test_snap_install_or_refresh_exception_raises(mock_snap, mock_workaround):
     """Test that when an exception happens, it will raise an exception to the caller."""
-    resource = mock.MagicMock(spec_set=service.SnapResource)
     mock_snap.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):
-        service.snap_install_or_refresh(resource, "my-channel")
+        service.snap_install_or_refresh("", "my-channel")
     mock_workaround.assert_not_called()
 
 
@@ -145,67 +116,3 @@ def test_remove_snap_as_resource_exception(mock_snap_remove, mock_snap_cache):
     mock_snap_remove.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):
         service.remove_snap_as_resource()
-
-
-@mock.patch("service.SquashFsImage.from_file")
-@mock.patch("service.yaml.safe_load")
-@mock.patch("service.os.path.getsize")
-def test_snap_resource(mock_size, mock_yaml, mock_image):
-    """Test the SnapResource class."""
-    model = mock.MagicMock(spec_set=service.Model)
-    mocked_resource = mock.MagicMock()
-    mocked_resource.absolute.return_value = path = "/var/resources/openstack-exporter.snap"
-    mock_size.return_value = size = 128
-    model.resources.fetch.return_value = mocked_resource
-    mock_file = mock.MagicMock()
-    mock_file.name = "snap.yaml"
-    mock_image.return_value.__enter__.return_value = [mock_file]
-    mock_image.__exit__.return_value = None
-
-    mock_yaml.return_value = {
-        "name": "golang-openstack-exporter",
-        "version": "latest",
-        "summary": "OpenStack Exporter for Prometheus",
-        "description": "The OpenStack exporter, exports Prometheus metrics",
-        "apps": {
-            "openstack-exporter": {
-                "command": "bin/openstack-exporter",
-                "plugs": ["home", "network", "network-bind"],
-                "command-chain": ["snap/command-chain/snapcraft-runner"],
-            }
-        },
-        "architectures": ["amd64"],
-        "assumes": ["command-chain"],
-        "base": "core18",
-        "confinement": "strict",
-        "grade": "devel",
-    }
-
-    resource = service.SnapResource("openstack-exporter", model)
-
-    assert resource.path == path
-    assert resource.size == size
-    assert resource.snap_name == "golang-openstack-exporter"
-
-
-def test_snap_resource_empty_path():
-    """Test snap resource when the path is empty."""
-    model = mock.MagicMock(spec_set=service.Model)
-    model.resources.fetch.side_effect = service.ModelError("Failed to fetch")
-
-    resource = service.SnapResource("openstack-exporter", model)
-    assert resource.path is None
-    assert resource.size is None
-    assert resource.snap_name is None
-
-
-@mock.patch("service.SquashFsImage.from_file")
-def test_snap_resource_err(mock_image):
-    """Test SnapResource fails to get the snap name."""
-    model = mock.MagicMock(spec_set=service.Model)
-    mock_image.side_effect = Exception("File not found")
-
-    resource = service.SnapResource("openstack-exporter", model)
-
-    with pytest.raises(service.snap.SnapError):
-        _ = resource.snap_name

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -42,9 +42,9 @@ def test_snap_install_or_refresh_with_resource_from_upstream(
     service.snap_install_or_refresh(resource, "my-channel")
     mock_remove_upstream.assert_called_once()
     mock_snap.install_local.assert_not_called()
-    mock_workaround.assert_called_once()
-    mock_remove_resource.assert_called_once()
-    mock_snap.add.assert_called_once_with(service.SNAP_NAME, channel="my-channel")
+    mock_workaround.assert_not_called()
+    mock_remove_resource.assert_not_called()
+    mock_snap.add.assert_not_called()
 
 
 @mock.patch("service.remove_upstream_snap")
@@ -58,6 +58,7 @@ def test_snap_install_or_refresh_snap_store(
     resource = mock.MagicMock(spec_set=service.SnapResource)
     resource.size = 0
     resource.snap_name = None
+    resource.__bool__.return_value = False
     service.snap_install_or_refresh(resource, "my-channel")
     resource.path = "/var/resources/openstack-exporter.snap"
     mock_remove_upstream.assert_called_once()
@@ -72,6 +73,9 @@ def test_snap_install_or_refresh_snap_store(
 def test_snap_install_or_refresh_exception_raises(mock_snap, mock_workaround):
     """Test that when an exception happens, it will raise an exception to the caller."""
     resource = mock.MagicMock(spec_set=service.SnapResource)
+    resource.size = 128
+    resource.snap_name = service.SNAP_NAME
+    resource.__bool__.return_value = True
     mock_snap.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):
         service.snap_install_or_refresh(resource, "my-channel")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -53,7 +53,7 @@ def test_snap_install_or_refresh_exception_raises(mock_snap, mock_workaround):
 def test_remove_upstream_snap(mock_snap):
     """Test remove upstream snap function."""
     service.remove_upstream_snap()
-    mock_snap.remove.assert_called_with(["golang-openstack-exporter"])
+    mock_snap.remove.assert_called_with([service.UPSTREAM_SNAP])
 
 
 @mock.patch("service.snap.remove")


### PR DESCRIPTION
- block units if upstream snap is installed via resource
- not run config-changed when upstream resource is used
- added func test showing that units go into blocked state if upstream resource is added.
- used snap cli to query snaps installed on functional tests

Closes: #94