### PR TITLE
Pass cacert as a file path to cloud.yaml

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,6 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         os.makedirs(os.path.dirname(OS_CLIENT_CONFIG), exist_ok=True)
         with open(OS_CLIENT_CONFIG_CACERT, "w") as f:
             f.write(self.config["ssl_ca"])
-        os.chmod(OS_CLIENT_CONFIG_CACERT, 0o644)
 
         auth_url = "{protocol}://{hostname}:{port}/v3".format(
             protocol=data["service_protocol"],

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,7 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         os.makedirs(os.path.dirname(OS_CLIENT_CONFIG), exist_ok=True)
         with open(OS_CLIENT_CONFIG_CACERT, "w") as f:
             f.write(self.config["ssl_ca"])
-        os.chmod(OS_CLIENT_CONFIG_CACERT, 0o600)
+        os.chmod(OS_CLIENT_CONFIG_CACERT, 0o644)
 
         auth_url = "{protocol}://{hostname}:{port}/v3".format(
             protocol=data["service_protocol"],

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,6 +10,7 @@ OpenStack deployment.
 
 import logging
 import os
+from pathlib import Path
 from typing import Any, Optional
 
 import ops
@@ -34,8 +35,8 @@ CLOUD_NAME = "openstack"
 # store the clouds.yaml where it's easily accessible by the openstack-exporter snap
 # This is the SNAP_COMMON directory for the exporter snap, which is accessible,
 # unversioned, and retained across updates of the snap.
-OS_CLIENT_CONFIG = f"/var/snap/{SNAP_NAME}/common/clouds.yaml"
-OS_CLIENT_CONFIG_CACERT = f"/var/snap/{SNAP_NAME}/common/cacert.pem"
+OS_CLIENT_CONFIG = Path(f"/var/snap/{SNAP_NAME}/common/clouds.yaml")
+OS_CLIENT_CONFIG_CACERT = Path(f"/var/snap/{SNAP_NAME}/common/cacert.pem")
 
 
 class OpenstackExporterOperatorCharm(ops.CharmBase):
@@ -91,9 +92,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         since v2 was removed a long time ago (Queens release)
         https://docs.openstack.org/keystone/latest/contributor/http-api.html
         """
-        os.makedirs(os.path.dirname(OS_CLIENT_CONFIG), exist_ok=True)
-        with open(OS_CLIENT_CONFIG_CACERT, "w") as f:
-            f.write(self.config["ssl_ca"])
+        OS_CLIENT_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        OS_CLIENT_CONFIG_CACERT.write_text(self.config["ssl_ca"])
 
         auth_url = "{protocol}://{hostname}:{port}/v3".format(
             protocol=data["service_protocol"],
@@ -115,13 +115,12 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
                         "auth_url": auth_url,
                     },
                     "verify": data["service_protocol"] == "https",
-                    "cacert": OS_CLIENT_CONFIG_CACERT,
+                    "cacert": str(OS_CLIENT_CONFIG_CACERT),
                 }
             }
         }
 
-        with open(OS_CLIENT_CONFIG, "w") as f:
-            yaml.dump(contents, f)
+        OS_CLIENT_CONFIG.write_text(yaml.dump(contents))
 
     def _get_keystone_data(self) -> dict[str, str]:
         """Get keystone data if ready, otherwise empty dict."""

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import yaml
 from zaza import model
 
-from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME, UPSTREAM_SNAP, OS_CLIENT_CONFIG_CACERT
+from charm import CLOUD_NAME, OS_CLIENT_CONFIG, OS_CLIENT_CONFIG_CACERT, SNAP_NAME, UPSTREAM_SNAP
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import yaml
 from zaza import model
 
-from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME, UPSTREAM_SNAP
+from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME, UPSTREAM_SNAP, OS_CLIENT_CONFIG_CACERT
 
 logger = logging.getLogger(__name__)
 
@@ -161,8 +161,11 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         results = model.run_on_leader(APP_NAME, command)
         clouds_yaml = results.get("Stdout", "").strip()
         data = yaml.safe_load(clouds_yaml)
-        cacert = data["clouds"][CLOUD_NAME]["cacert"]
-        self.assertEqual(cacert, f"{new_value}")
+        cacert_path = data["clouds"][CLOUD_NAME]["cacert"]
+        self.assertEqual(cacert_path, OS_CLIENT_CONFIG_CACERT)
+
+        with open(cacert_path, "r") as f:
+            self.assertEqual(f.read(), f"{new_value}")
 
         # Verify the exporter crashes because of wrong ssl_ca
         command = "curl -q localhost:9180/metrics"

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -164,8 +164,11 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         cacert_path = data["clouds"][CLOUD_NAME]["cacert"]
         self.assertEqual(cacert_path, OS_CLIENT_CONFIG_CACERT)
 
-        with open(cacert_path, "r") as f:
-            self.assertEqual(f.read(), f"{new_value}")
+        # Verify ssl_ca was written to the file
+        command = f"sudo cat {cacert_path}"
+        results = model.run_on_leader(APP_NAME, command)
+        cacert = results.get("Stdout", "").strip()
+        self.assertEqual(f"{cacert}", f"{new_value}")
 
         # Verify the exporter crashes because of wrong ssl_ca
         command = "curl -q localhost:9180/metrics"

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -45,7 +45,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         results = model.run_on_leader(APP_NAME, command)
         clouds_yaml_path = results.get("Stdout", "").strip()
         self.assertEqual(int(results.get("Code", "-1")), 0)
-        self.assertEqual(clouds_yaml_path, OS_CLIENT_CONFIG)
+        self.assertEqual(clouds_yaml_path, str(OS_CLIENT_CONFIG))
 
         # Make sure the clouds yaml is not empty and it's a valid yaml
         command = f"cat $(sudo snap get {SNAP_NAME} os-client-config)"
@@ -162,7 +162,7 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         clouds_yaml = results.get("Stdout", "").strip()
         data = yaml.safe_load(clouds_yaml)
         cacert_path = data["clouds"][CLOUD_NAME]["cacert"]
-        self.assertEqual(cacert_path, OS_CLIENT_CONFIG_CACERT)
+        self.assertEqual(cacert_path, str(OS_CLIENT_CONFIG_CACERT))
 
         # Verify ssl_ca was written to the file
         command = f"sudo cat {cacert_path}"

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import yaml
 from zaza import model
 
-from charm import CLOUD_NAME, OS_CLIENT_CONFIG, OS_CLIENT_CONFIG_CACERT, SNAP_NAME, UPSTREAM_SNAP
+from charm import CLOUD_NAME, OS_CLIENT_CONFIG, SNAP_NAME, UPSTREAM_SNAP
 
 logger = logging.getLogger(__name__)
 
@@ -162,13 +162,9 @@ class OpenstackExporterConfigTest(OpenstackExporterBaseTest):
         clouds_yaml = results.get("Stdout", "").strip()
         data = yaml.safe_load(clouds_yaml)
         cacert_path = data["clouds"][CLOUD_NAME]["cacert"]
-        self.assertEqual(cacert_path, str(OS_CLIENT_CONFIG_CACERT))
 
         # Verify ssl_ca was written to the file
-        command = f"sudo cat {cacert_path}"
-        results = model.run_on_leader(APP_NAME, command)
-        cacert = results.get("Stdout", "").strip()
-        self.assertEqual(f"{cacert}", f"{new_value}")
+        model.block_until_file_has_contents(APP_NAME, cacert_path, new_value)
 
         # Verify the exporter crashes because of wrong ssl_ca
         command = "curl -q localhost:9180/metrics"

--- a/tests/integration/tests/charm_tests/setup.py
+++ b/tests/integration/tests/charm_tests/setup.py
@@ -12,6 +12,6 @@ def setup_export_ssl_ca_config():
     model.set_application_config("openstack-exporter", {"ssl_ca": cacert})
     model.block_until_file_has_contents(
         "openstack-exporter",
-        f"/var/snap/{SNAP_NAME}/common/clouds.yaml",
+        f"/var/snap/{SNAP_NAME}/common/cacert.pem",
         "-----BEGIN CERTIFICATE-----",
     )


### PR DESCRIPTION
Instead of passing a string of a cacert to `cloud.yaml`, write it in the file alongside and store the filepath in the config.

Closes: #97