### PR TITLE
Raise errors on unrecoverable problems

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 import ops
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from charms.operator_libs_linux.v2.snap import SnapError
 from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus
 
 from service import SNAP_NAME, UPSTREAM_SNAP, get_installed_snap_service, snap_install_or_refresh

--- a/src/charm.py
+++ b/src/charm.py
@@ -149,6 +149,7 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """Install the necessary resources for the charm."""
         # If this fails, it's not recoverable.
         # So we don't catch the error, instead letting this become a charm error status.
+        # Errored hooks are auto-retried by juju, so the install may work on retry.
         snap_install_or_refresh(self.get_resource(), self.model.config["snap_channel"])
 
     def _configure(self, _: ops.HookEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -225,11 +225,19 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         if not snap_service.present:
             event.add_status(
-                BlockedStatus(f"{SNAP_NAME} snap is not installed. Please wait for installation to complete, or manually reinstall the snap if the issue persists.")
+                BlockedStatus(
+                    f"{SNAP_NAME} snap is not installed. "
+                    "Please wait for installation to complete, "
+                    "or manually reinstall the snap if the issue persists."
+                )
             )
         elif not snap_service.is_active():
             event.add_status(
-                BlockedStatus(f"{SNAP_NAME} snap service is not active. Please wait for configuration to complete, or manually start the service the issue persists.")
+                BlockedStatus(
+                    f"{SNAP_NAME} snap service is not active. "
+                    "Please wait for configuration to complete, "
+                    "or manually start the service the issue persists."
+                )
             )
 
         event.add_status(ActiveStatus())

--- a/src/charm.py
+++ b/src/charm.py
@@ -203,12 +203,10 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if not self.model.relations.get("credentials"):
             event.add_status(BlockedStatus("Keystone is not related"))
 
-        keystone_data = self._get_keystone_data()
-        if not keystone_data:
+        if not self._get_keystone_data():
             event.add_status(WaitingStatus("Waiting for credentials from keystone"))
 
-        cos_agent_relation = self.model.relations.get("cos-agent")
-        if not cos_agent_relation:
+        if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
 
         upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
@@ -225,11 +223,13 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         snap_service = get_installed_snap_service(SNAP_NAME)
 
         if not snap_service.present:
-            raise RuntimeError(f"{SNAP_NAME} snap is not installed")
-
-        # the snap service should be active, but it isn't, then it's an unknown error
-        if keystone_data and cos_agent_relation and not snap_service.is_active():
-            raise RuntimeError(f"{SNAP_NAME} snap service is not active")
+            event.add_status(
+                BlockedStatus(f"{SNAP_NAME} snap is not installed; please manually check")
+            )
+        elif not snap_service.is_active():
+            event.add_status(
+                BlockedStatus(f"{SNAP_NAME} snap service is not active; please manually check")
+            )
 
         event.add_status(ActiveStatus())
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,10 +51,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
-        self.framework.observe(self.on.credentials_relation_joined, self._configure)
         self.framework.observe(self.on.credentials_relation_changed, self._configure)
         self.framework.observe(self.on.credentials_relation_broken, self._configure)
-        self.framework.observe(self.on.cos_agent_relation_joined, self._configure)
         self.framework.observe(self.on.cos_agent_relation_changed, self._configure)
         self.framework.observe(self.on.cos_agent_relation_broken, self._configure)
 
@@ -205,18 +203,16 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """Handle collect unit status event (called after every event)."""
         if not self.model.relations.get("credentials"):
             event.add_status(BlockedStatus("Keystone is not related"))
-            return
 
         if not self._get_keystone_data():
             event.add_status(WaitingStatus("Waiting for credentials from keystone"))
-            return
 
         if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
-            return
+
+        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
 
         # this is necessary when doing a charm upgrade coming from revision 27
-        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
         if upstream_snap.present:
             event.add_status(
                 BlockedStatus(
@@ -224,15 +220,17 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
                     "https://charmhub.io/openstack-exporter#known-issues"
                 )
             )
-            return
 
         snap_service = get_installed_snap_service(SNAP_NAME)
 
         if not snap_service.present:
-            raise RuntimeError(f"{SNAP_NAME} snap is not installed, but it should be")
-
-        if not snap_service.is_active():
-            raise RuntimeError(f"{SNAP_NAME} snap service is not active, but it should be")
+            event.add_status(
+                BlockedStatus(f"{SNAP_NAME} snap is not installed. Please wait for installation to complete, or manually reinstall the snap if the issue persists.")
+            )
+        elif not snap_service.is_active():
+            event.add_status(
+                BlockedStatus(f"{SNAP_NAME} snap service is not active. Please wait for configuration to complete, or manually start the service the issue persists.")
+            )
 
         event.add_status(ActiveStatus())
 

--- a/tests/integration/tests/charm_tests/openstack_exporter.py
+++ b/tests/integration/tests/charm_tests/openstack_exporter.py
@@ -246,9 +246,9 @@ class OpenstackExporterStatusTest(OpenstackExporterBaseTest):
         model.block_until_unit_wl_status(
             self.leader_unit_entity_id, "blocked", timeout=STATUS_TIMEOUT
         )
-        self.assertEqual(
+        self.assertIn(
+            "snap service is not active",
             self.leader_unit.workload_status_message,
-            "snap service is not running, please check snap service",
         )
 
         # Start the exporter snap

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,14 +8,15 @@ from unittest import mock
 import ops
 import ops.testing
 import pytest
-from ops.model import BlockedStatus
+from ops.model import ErrorStatus
+
+from charms.operator_libs_linux.v2.snap import SnapError
 
 from charm import (
     CLOUD_NAME,
     OS_CLIENT_CONFIG,
     SNAP_NAME,
     OpenstackExporterOperatorCharm,
-    SnapError,
 )
 from service import SnapService
 
@@ -106,6 +107,5 @@ class TestCharm:
     def test_install_snap_error(self, mock_install):
         mock_install.side_effect = SnapError("My Error")
         self.harness.begin()
-        self.harness.charm.on.install.emit()
-        expected_msg = "Failed to remove/install openstack-exporter snap"
-        assert self.harness.charm.unit.status == BlockedStatus(expected_msg)
+        with pytest.raises(SnapError, match="My Error"):
+            self.harness.charm.on.install.emit()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,8 +8,6 @@ from unittest import mock
 import ops
 import ops.testing
 import pytest
-from ops.model import ErrorStatus
-
 from charms.operator_libs_linux.v2.snap import SnapError
 
 from charm import (


### PR DESCRIPTION
Raise errors for snap install or refresh failure.  Raise an error because it's a fatal failure, and juju will auto-retry the hook, which may succeed on retry if the error was transient.

Improve blocked status message for if it detects snap not installed or service not active in the status hook.
I think Blocked is better than Error status here:
- auto retrying the status hook isn't going to fix anything
- blocked status lets the charm provide a more useful status message to the user
- blocked status will automatically update to active on the next update-status hook once the issue is resolved


Partially fixes: #108