### PR TITLE
Enter blocked status if resource and snap_channel

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -69,7 +69,7 @@ config:
         The charmed-openstack-exporter snap is by default installed from the latest/stable channel.
         This option allows the selection of a different channel.
 
-        In case the openStack-exporter resource has been attached, this option has no effect.
+        If the snap file has been attached via the openstack-exporter resource, this option has no effect.
 
 
 links:
@@ -92,4 +92,5 @@ resources:
       ignore an empty file resource and normally install the snap from the snap store, but a
       custom snap can also be provided here if needed.
 
-      This resource has top priority. If the resource is present, the snap_channel option will have no effect.
+      This resource has priority: if this resource is present,
+      the snap will be installed from the resource, and the snap_channel option will have no effect.

--- a/src/charm.py
+++ b/src/charm.py
@@ -228,8 +228,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if self.model.config["snap_channel"] != "latest/stable" and self.get_resource():
             event.add_status(
                 BlockedStatus(
-                    "The snap_channel option is unused when snap resource is provided. "
-                    f"Please unset it: juju config {self.app.name} --unset snap_channel"
+                    "snap_channel is unused when snap resource provided; "
+                    f"please unset it: juju config {self.app.name} --reset snap_channel"
                 )
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -228,7 +228,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if self.model.config["snap_channel"] != "latest/stable" and self.get_resource():
             event.add_status(
                 BlockedStatus(
-                    "Unset snap_channel option: it is unused when snap resource is provided."
+                    "The snap_channel option is unused when snap resource is provided. "
+                    f"Please unset it: juju config {self.app.name} --unset snap_channel"
                 )
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -228,8 +228,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if self.model.config["snap_channel"] != "latest/stable" and self.get_resource():
             event.add_status(
                 BlockedStatus(
-                    "snap_channel is unused when snap resource provided; "
-                    f"please unset it: juju config {self.app.name} --reset snap_channel"
+                    "Snap resource provided, so snap_channel is unused. "
+                    f"Please unset it: juju config {self.app.name} --reset snap_channel"
                 )
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -223,6 +223,15 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         snap_service = get_installed_snap_service(SNAP_NAME)
 
+        # The snap_channel config option is ignored if there is a snap resource,
+        # so warn the user.
+        if self.model.config["snap_channel"] != "latest/stable" and self.get_resource():
+            event.add_status(
+                BlockedStatus(
+                    "Unset snap_channel option: it is unused when snap resource is provided."
+                )
+            )
+
         if not snap_service.present:
             event.add_status(
                 BlockedStatus(


### PR DESCRIPTION
When a resource is used, the `snap_channel` config option is ignored. In this case, the snap is installed directly from the resource file, so a "channel" doesn't make sense.

If `snap_channel` is set and a resource is being used, it may indicate a confusion situation,
such as the user changing the `snap_channel`
and wondering why the snap isn't being updated.
So the charm can alert the user to this situation
via a message and blocked status.

Fixes: #113