### PR TITLE
Add limit:1 in the cos-agent relation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,6 +23,7 @@ requires:
 provides:
   cos-agent:
     interface: cos_agent
+    limit: 1
 
 # These bindings can be used to explicitly request interfaces in all the OpenStack
 # network spaces. Needed when APIs are not exposed in the same network as the one bound


### PR DESCRIPTION
Not limiting the amount of relations you can establish through this interface may lead to weird situations.

For more context: https://discourse.charmhub.io/t/one-grafana-agent-charm-to-rule-them-all/16014

---

Copy of #122 but fire from upstream branch.