### PR TITLE
Attempt to fix functional tests

### DIFF
--- a/tests/integration/tests/bundles/jammy-yoga.yaml
+++ b/tests/integration/tests/bundles/jammy-yoga.yaml
@@ -26,9 +26,11 @@ applications:
     charm: mysql-router
     channel: latest/edge
   mysql:
-    charm: mysql
-    channel: 8.0/edge
-    num_units: 1
+    charm: mysql-innodb-cluster
+    channel: latest/edge
+    options:
+      source: *openstack-origin
+    num_units: 3
   glance:
     charm: glance
     channel: yoga/edge

--- a/tests/integration/tests/bundles/jammy-yoga.yaml
+++ b/tests/integration/tests/bundles/jammy-yoga.yaml
@@ -15,7 +15,6 @@ applications:
     num_units: 1
     options:
       openstack-origin: *openstack-origin
-    constraints: arch=amd64 mem=1024
   keystone-mysql-router:
     charm: mysql-router
     channel: latest/edge
@@ -30,14 +29,12 @@ applications:
     charm: mysql
     channel: 8.0/edge
     num_units: 1
-    constraints: arch=amd64 mem=4096
   glance:
     charm: glance
     channel: yoga/edge
     num_units: 1
     options:
       openstack-origin: *openstack-origin
-    constraints: arch=amd64 mem=1024
   glance-mysql-router:
     charm: mysql-router
     channel: latest/edge
@@ -55,7 +52,6 @@ applications:
       openstack-origin: *openstack-origin
       verbose: true
       debug: true
-    constraints: arch=amd64 mem=4096
   nova-cloud-controller-mysql-router:
     charm: mysql-router
     channel: latest/edge
@@ -68,7 +64,6 @@ applications:
       network-manager: Neutron
       openstack-origin: distro
       verbose: true
-    constraints: arch=amd64 mem=2048
   neutron-api:
     charm: neutron-api
     channel: yoga/edge
@@ -82,7 +77,6 @@ applications:
       path-mtu: 1550
       physical-network-mtus: physnet1:1500
       verbose: true
-    constraints: arch=amd64 mem=2048
   neutron-api-mysql-router:
     charm: mysql-router
     channel: latest/edge
@@ -92,7 +86,6 @@ applications:
     num_units: 1
     options:
       min-cluster-size: 1
-    constraints: arch=amd64 mem=1024
   placement:
     charm: placement
     channel: yoga/edge
@@ -100,7 +93,6 @@ applications:
     options:
       debug: true
       openstack-origin: *openstack-origin
-    constraints: arch=amd64 mem=1024
   placement-mysql-router:
     charm: mysql-router
     channel: latest/edge
@@ -113,7 +105,6 @@ applications:
     num_units: 3
     options:
       source: distro
-    constraints: arch=amd64 mem=2048
   ovn-chassis:
     charm: ovn-chassis
     channel: 22.03/stable

--- a/tests/integration/tests/bundles/jammy-yoga.yaml
+++ b/tests/integration/tests/bundles/jammy-yoga.yaml
@@ -28,7 +28,7 @@ applications:
     channel: latest/edge
   mysql:
     charm: mysql
-    channel: latest/edge
+    channel: 8.0/edge
     num_units: 1
     constraints: arch=amd64 mem=4096
   glance:
@@ -120,6 +120,7 @@ applications:
     options:
       debug: true
       ovn-bridge-mappings: physnet1:br-data
+
 relations:
 - - nova-cloud-controller:shared-db
   - nova-cloud-controller-mysql-router:shared-db

--- a/tests/integration/tests/bundles/jammy-yoga.yaml
+++ b/tests/integration/tests/bundles/jammy-yoga.yaml
@@ -27,11 +27,9 @@ applications:
     charm: mysql-router
     channel: latest/edge
   mysql:
-    charm: mysql-innodb-cluster
+    charm: mysql
     channel: latest/edge
-    options:
-      source: *openstack-origin
-    num_units: 3
+    num_units: 1
     constraints: arch=amd64 mem=4096
   glance:
     charm: glance


### PR DESCRIPTION
Functional tests are failing on main,
with errors from the mysql cluster.
It's potentially due to the model being too large to deploy on the runner and be stable, or it could be related to flakiness in the mysql-innodb-cluster charm. Either way, let's try to switch to the new mysql charm that can be deployed in non HA mode by only deploying a single unit. This should reduce resource use, and also perhaps be more stable.