### PR TITLE
Add validation to some config options 

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus
 
 from service import SNAP_NAME, UPSTREAM_SNAP, get_installed_snap_service, snap_install_or_refresh
-from validate_config import validate_cache_ttl, validate_port, validate_snap_channel
+from validate_config import validate_cache_ttl, validate_port
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +155,6 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         validators: list[tuple[Callable, str]] = [
             (validate_port, "port"),
             (validate_cache_ttl, "cache_ttl"),
-            (validate_snap_channel, "snap_channel"),
         ]
         for validator, config_key in validators:
             if error := validator(self.model.config[config_key]):

--- a/src/charm.py
+++ b/src/charm.py
@@ -224,6 +224,9 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent) -> None:
         """Handle collect unit status event (called after every event)."""
+        if config_error := self.validate_configs():
+            event.add_status(BlockedStatus(config_error))
+
         if not self.model.relations.get("credentials"):
             event.add_status(BlockedStatus("Keystone is not related"))
 

--- a/src/validate_config.py
+++ b/src/validate_config.py
@@ -24,8 +24,10 @@ def validate_cache_ttl(cache_ttl: str) -> Optional[str]:
 
     """
     if not re.match(r"^\d+[smhd]$", cache_ttl):
-        return f"cache_ttl must be in format <number><unit> \
-                where unit is s, m, h, or d, got {cache_ttl}"
+        return (
+            f"cache_ttl must be in format <number><unit> "
+            f"where unit is s, m, h, or d, got {cache_ttl}"
+        )
     return None
 
 
@@ -37,6 +39,8 @@ def validate_snap_channel(snap_channel: str) -> Optional[str]:
     """
     if snap_channel != "latest/stable":
         if not re.match(r"^(latest/|[^/]+/)(stable|candidate|beta|edge)$", snap_channel):
-            return f"Invalid snap_channel, must be one of 'latest/stable', \
-                'latest/candidate', 'latest/beta', 'latest/edge', got {snap_channel}"
+            return (
+                f"Invalid snap_channel, must be one of 'latest/stable', 'latest/candidate', "
+                f"'latest/beta', 'latest/edge', got {snap_channel}"
+            )
     return None

--- a/src/validate_config.py
+++ b/src/validate_config.py
@@ -1,0 +1,42 @@
+"""Configuration validation functions."""
+
+import re
+from typing import Optional
+
+MAX_PORT = 65535
+
+
+def validate_port(port: int) -> Optional[str]:
+    """Validate port configuration.
+
+    Return error message if invalid, None if valid.
+
+    """
+    if port <= 0 or port > MAX_PORT:
+        return f"Port must be between 1 and {MAX_PORT}, got {port}"
+    return None
+
+
+def validate_cache_ttl(cache_ttl: str) -> Optional[str]:
+    """Validate cache_ttl configuration.
+
+    Return error message if invalid, None if valid.
+
+    """
+    if not re.match(r"^\d+[smhd]$", cache_ttl):
+        return f"cache_ttl must be in format <number><unit> \
+                where unit is s, m, h, or d, got {cache_ttl}"
+    return None
+
+
+def validate_snap_channel(snap_channel: str) -> Optional[str]:
+    """Validate snap_channel configuration.
+
+    Return error message if invalid, None if valid.
+
+    """
+    if snap_channel != "latest/stable":
+        if not re.match(r"^(latest/|[^/]+/)(stable|candidate|beta|edge)$", snap_channel):
+            return f"Invalid snap_channel, must be one of 'latest/stable', \
+                'latest/candidate', 'latest/beta', 'latest/edge', got {snap_channel}"
+    return None

--- a/src/validate_config.py
+++ b/src/validate_config.py
@@ -5,6 +5,15 @@ from typing import Optional
 
 MAX_PORT = 65535
 
+# Allowable duration units for cache_ttl from https://pkg.go.dev/time#ParseDuration
+VALID_UNITS = {"ns", "us", "\u05bcs", "\u03bcs", "ms", "s", "m", "h"}
+
+# Regex patterns for cache_ttl
+NUMBER_PATTERN = r"(\d+\.?\d*|\d*\.\d+)"
+DURATION_PATTERN = (
+    rf"^\+?{NUMBER_PATTERN}[a-zµ\u03bc\u05bc]+({NUMBER_PATTERN}[a-zµ\u03bc\u05bc]+)*$"
+)
+
 
 def validate_port(port: int) -> Optional[str]:
     """Validate port configuration.
@@ -20,14 +29,32 @@ def validate_port(port: int) -> Optional[str]:
 def validate_cache_ttl(cache_ttl: str) -> Optional[str]:
     """Validate cache_ttl configuration.
 
+    Allow patterns in https://pkg.go.dev/time#ParseDuration,
+    Add constraints for negative and zero values.
+    No overflow checks (ParseDuration can handle extremely large values appropriately at runtime)
+
     Return error message if invalid, None if valid.
 
     """
-    if not re.match(r"^\d+[smhd]$", cache_ttl):
-        return (
-            f"cache_ttl must be in format <number><unit> "
-            f"where unit is s, m, h, or d, got {cache_ttl}"
-        )
+    if not cache_ttl or cache_ttl[0] == "-":
+        return f"Cache_ttl must be non-empty and non-negative. Got {cache_ttl}"
+
+    # Validate overall format
+    if not re.fullmatch(DURATION_PATTERN, cache_ttl):
+        return f"Invalid regex format. Valid pattern is {DURATION_PATTERN}. Got {cache_ttl}"
+
+    # Get each number-unit pair
+    matches = re.findall(r"(\d+\.?\d*|\d*\.\d+)([a-zµ\u03bc\u05bc]+)", cache_ttl)
+
+    # Validate non-zero duration
+    if not any(float(number) for number, _ in matches):
+        return f"Cache_ttl must be non-zero. Got {cache_ttl}"
+
+    # Validate units
+    for _, unit in matches:
+        if unit not in VALID_UNITS:
+            return f"Invalid time unit {unit}. Valid units are {VALID_UNITS}."
+
     return None
 
 
@@ -37,10 +64,14 @@ def validate_snap_channel(snap_channel: str) -> Optional[str]:
     Return error message if invalid, None if valid.
 
     """
-    if snap_channel != "latest/stable":
-        if not re.match(r"^(latest/|[^/]+/)(stable|candidate|beta|edge)$", snap_channel):
+    if "/" not in snap_channel:
+        return f"Invalid snap_channel format: {snap_channel}. Expected format like 'track/risk'."
+
+    parts = snap_channel.split("/")
+    for part in parts:
+        if not part:
             return (
-                f"Invalid snap_channel, must be one of 'latest/stable', 'latest/candidate', "
-                f"'latest/beta', 'latest/edge', got {snap_channel}"
+                f"Invalid snap_channel format: {snap_channel}. Expected format like 'track/risk'."
             )
+
     return None

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -598,7 +598,17 @@ class TestCharm:
             ("cache_ttl", "300s"),
             ("cache_ttl", "300m"),
             ("cache_ttl", "300h"),
-            ("cache_ttl", "300d"),
+            ("cache_ttl", "+1s"),
+            ("cache_ttl", ".1m"),
+            ("cache_ttl", "5.s"),
+            ("cache_ttl", "5\u05bcs"),
+            ("cache_ttl", "5\u03bcs"),
+            ("cache_ttl", "30s"),
+            ("cache_ttl", "3h30m"),
+            ("cache_ttl", "10.5s4m"),
+            ("cache_ttl", "2m3.4s"),
+            ("cache_ttl", "1h2m3s4ms5us6ns"),
+            ("cache_ttl", "39h9m14s"),
             ("snap_channel", "latest/stable"),
             ("snap_channel", "latest/candidate"),
             ("snap_channel", "latest/beta"),
@@ -630,14 +640,24 @@ class TestCharm:
             ("port", 0),
             ("port", -1),
             ("port", 65536),
-            ("cache_ttl", "300.1s"),
-            ("cache_ttl", "300 seconds"),
-            ("cache_ttl", "300 s"),
-            ("cache_ttl", "300y"),
-            ("snap_channel", "invalid/channel"),
-            ("snap_channel", "latest-stable"),
-            ("snap_channel", "Latest/Beta"),
-            ("snap_channel", "latest/edge/"),
+            ("cache_ttl", ""),
+            ("cache_ttl", "3"),
+            ("cache_ttl", "-"),
+            ("cache_ttl", "+"),
+            ("cache_ttl", "s"),
+            ("cache_ttl", "."),
+            ("cache_ttl", "0"),
+            ("cache_ttl", "+0s"),
+            ("cache_ttl", "-."),
+            ("cache_ttl", "-3h30m"),
+            ("cache_ttl", "0s0m"),
+            ("cache_ttl", ".s"),
+            ("cache_ttl", "+.s"),
+            ("cache_ttl", "1d"),
+            ("snap_channel", "/invalidchannel"),
+            ("snap_channel", "latest-stable/"),
+            ("snap_channel", "Latest/Beta/"),
+            ("snap_channel", "/latest/edge"),
         ],
     )
     def test_config_change_with_invalid_config(self, config_option, cofig_value, mocker):
@@ -648,8 +668,8 @@ class TestCharm:
         elif config_option == "cache_ttl":
             validate_function = "charm.validate_cache_ttl"
             error_msg = (
-                f"cache_ttl must be in format <number><unit> "
-                f"where unit is s, m, h, or d, got {cofig_value}"
+                f"cache_ttl must be non-negative, non-zero, "
+                f"and in correct pattern, got {cofig_value}"
             )
         elif config_option == "snap_channel":
             validate_function = "charm.validate_snap_channel"

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -32,31 +32,87 @@ def test_validate_port_invalid(port):
 @pytest.mark.parametrize(
     "cache_ttl",
     [
-        "1s",
-        "1m",
-        "1h",
-        "1d",
+        "5s",
+        "30s",
+        "1478s",
+        "+5s",
+        "5.0s",
+        "5.6s",
+        "5.s",
+        ".5s",
+        "1.0s",
+        "1.00s",
+        "1.004s",
+        "1.0040s",
+        "100.00100s",
+        "10ns",
+        "11us",
+        "12\u05bcs",  # U+00B5
+        "12\u03bcs",  # U+03BC
+        "13ms",
+        "14s",
+        "15m",
+        "16h",
+        "3h30m",
+        "10.5s4m",
+        "2m3.4s",
+        "1h2m3s4ms5us6ns",
+        "39h9m14.425s",
+        "52763797000ns",
+        "0.3333333333333333333h",
+        "9007199254740993ns",
+        "9223372036854775807ns",
+        "9223372036854775.807us",
+        "9223372036s854ms775us807ns",
+        "+9223372036854775808ns",
+        "+9223372036854775.808us",
+        "+9223372036s854ms775us808ns",
+        "+2562047h47m16.854775808s",
+        "0.100000000000000000000h",
+        "0.830103483285477580700h",
     ],
 )
 def test_validate_cache_ttl_valid(cache_ttl):
-    """Test validate cache_ttl function with valid cache_ttl."""
+    """Test validate cache_ttl function with valid cache_ttl.
+
+    Test cases from https://cs.opensource.google/go/go/+/master:src/time/time_test.go;l=994
+    Exclude zero and negative sign values.
+
+    """
     assert validate_cache_ttl(cache_ttl) is None
 
 
 @pytest.mark.parametrize(
     "cache_ttl",
     [
-        "1",
-        "1x",
-        "1ms",
-        "1y",
+        "",
+        "3",
+        "-",
+        "+",
+        "s",
+        ".",
+        "0",
+        "+0s-.",
+        "-3h30m",
+        "0s0m",
+        ".s",
+        "+.s",
+        "1d",
+        "\x85\x85",
+        "\xffff",
+        "hello \xffff world",
+        "\ufffd",  # utf8.RuneError
+        "\ufffd hello \ufffd world",  # utf8.RuneError
     ],
 )
 def test_validate_cache_ttl_invalid(cache_ttl):
-    """Test validate cache_ttl function with invalid cache_ttl."""
-    assert validate_cache_ttl(cache_ttl) == (
-        f"cache_ttl must be in format <number><unit> where unit is s, m, h, or d, got {cache_ttl}"
-    )
+    """Test validate cache_ttl function with invalid cache_ttl.
+
+    Test cases from https://cs.opensource.google/go/go/+/master:src/time/time_test.go;l=994
+    Added invalid cases for empty string, zero value, single unit, and negative sign.
+
+    """
+    assert validate_cache_ttl(cache_ttl) is not None
 
 
 @pytest.mark.parametrize(
@@ -66,6 +122,8 @@ def test_validate_cache_ttl_invalid(cache_ttl):
         "latest/candidate",
         "latest/beta",
         "latest/edge",
+        "v32/beta",
+        "latest/edge/test-fix-bug1",
     ],
 )
 def test_validate_snap_channel_valid(snap_channel):
@@ -76,15 +134,18 @@ def test_validate_snap_channel_valid(snap_channel):
 @pytest.mark.parametrize(
     "snap_channel",
     [
-        "invalid/channel",
-        "latest-stable",
-        "Latest/Beta",
-        "latest/edge/",
+        "",
+        "invalid-channel",
+        "/latest/stable",
+        "LatestBeta",
+        "latestedge/",
+        "v1/edge/",
+        "latest//edge",
+        "//latest/edge",
     ],
 )
 def test_validate_snap_channel_invalid(snap_channel):
     """Test validate snap_channel function with invalid snap_channel."""
     assert validate_snap_channel(snap_channel) == (
-        f"Invalid snap_channel, must be one of 'latest/stable', 'latest/candidate', "
-        f"'latest/beta', 'latest/edge', got {snap_channel}"
+        f"Invalid snap_channel format: {snap_channel}. Expected format like 'track/risk'."
     )

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1,0 +1,90 @@
+import pytest
+
+from validate_config import validate_cache_ttl, validate_port, validate_snap_channel
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        9180,
+        1,
+        65535,
+    ],
+)
+def test_validate_port_valid(port):
+    """Test validate port function with valid ports."""
+    assert validate_port(port) is None
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        0,
+        -1,
+        65536,
+    ],
+)
+def test_validate_port_invalid(port):
+    """Test validate port function with invalid ports."""
+    assert validate_port(port) == f"Port must be between 1 and 65535, got {port}"
+
+
+@pytest.mark.parametrize(
+    "cache_ttl",
+    [
+        "1s",
+        "1m",
+        "1h",
+        "1d",
+    ],
+)
+def test_validate_cache_ttl_valid(cache_ttl):
+    """Test validate cache_ttl function with valid cache_ttl."""
+    assert validate_cache_ttl(cache_ttl) is None
+
+
+@pytest.mark.parametrize(
+    "cache_ttl",
+    [
+        "1",
+        "1x",
+        "1ms",
+        "1y",
+    ],
+)
+def test_validate_cache_ttl_invalid(cache_ttl):
+    """Test validate cache_ttl function with invalid cache_ttl."""
+    assert validate_cache_ttl(cache_ttl) == (
+        f"cache_ttl must be in format <number><unit> where unit is s, m, h, or d, got {cache_ttl}"
+    )
+
+
+@pytest.mark.parametrize(
+    "snap_channel",
+    [
+        "latest/stable",
+        "latest/candidate",
+        "latest/beta",
+        "latest/edge",
+    ],
+)
+def test_validate_snap_channel_valid(snap_channel):
+    """Test validate snap_channel function with valid snap_channel."""
+    assert validate_snap_channel(snap_channel) is None
+
+
+@pytest.mark.parametrize(
+    "snap_channel",
+    [
+        "invalid/channel",
+        "latest-stable",
+        "Latest/Beta",
+        "latest/edge/",
+    ],
+)
+def test_validate_snap_channel_invalid(snap_channel):
+    """Test validate snap_channel function with invalid snap_channel."""
+    assert validate_snap_channel(snap_channel) == (
+        f"Invalid snap_channel, must be one of 'latest/stable', 'latest/candidate', "
+        f"'latest/beta', 'latest/edge', got {snap_channel}"
+    )

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from validate_config import validate_cache_ttl, validate_port, validate_snap_channel
+from validate_config import validate_cache_ttl, validate_port
 
 
 @pytest.mark.parametrize(
@@ -47,7 +47,7 @@ def test_validate_port_invalid(port):
         "100.00100s",
         "10ns",
         "11us",
-        "12\u05bcs",  # U+00B5
+        "12\u00b5s",  # U+00B5
         "12\u03bcs",  # U+03BC
         "13ms",
         "14s",
@@ -113,39 +113,3 @@ def test_validate_cache_ttl_invalid(cache_ttl):
 
     """
     assert validate_cache_ttl(cache_ttl) is not None
-
-
-@pytest.mark.parametrize(
-    "snap_channel",
-    [
-        "latest/stable",
-        "latest/candidate",
-        "latest/beta",
-        "latest/edge",
-        "v32/beta",
-        "latest/edge/test-fix-bug1",
-    ],
-)
-def test_validate_snap_channel_valid(snap_channel):
-    """Test validate snap_channel function with valid snap_channel."""
-    assert validate_snap_channel(snap_channel) is None
-
-
-@pytest.mark.parametrize(
-    "snap_channel",
-    [
-        "",
-        "invalid-channel",
-        "/latest/stable",
-        "LatestBeta",
-        "latestedge/",
-        "v1/edge/",
-        "latest//edge",
-        "//latest/edge",
-    ],
-)
-def test_validate_snap_channel_invalid(snap_channel):
-    """Test validate snap_channel function with invalid snap_channel."""
-    assert validate_snap_channel(snap_channel) == (
-        f"Invalid snap_channel format: {snap_channel}. Expected format like 'track/risk'."
-    )


### PR DESCRIPTION
Closes #49  
- Create validation methods for 'port' and 'cache_ttl' config options
- Add validation check to the handler of config_changed event and set block status

ps: 
- 'cache' isn't much to validate for a boolean value and Juju can automatically reject non-boolean values.
-  for 'snap_channel' it's not practical to catch all invalid cases. Also the invalid setup can be noticed easily in Juju logs
- 'ssl_ca' is more complex to validate properly and it's not the charm's duty to verify this but the OpenStack client instead. The integration test also confirms that an invalid CA certificate will cause expected failures