### PR TITLE
[DNM] Dashboard modification to detect fully Ceph-backed deployment

### DIFF
--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -1068,7 +1068,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "(sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes))",
+          "expr": "(${ceph_without_ephemeral} == 1) * (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes) or ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes)))",
           "intervalFactor": 2,
           "legendFormat": "{{aggregate}}",
           "refId": "A",
@@ -1669,6 +1669,39 @@
         "regex": ".*aggregates=\"([^\"]+).*",
         "skipUrlSync": false,
         "sort": 0,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "",
+        "description": "Detects if Ceph backend is used without ephemeral storage",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Ceph Detection",
+        "multi": false,
+        "name": "ceph_without_ephemeral",
+        "options": [],
+        "query": {
+          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 5000000000))",
+          "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
         "type": "query",
         "useTags": false
       }

--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -1068,7 +1068,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "(${ceph_without_ephemeral} * (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes)) or ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes)))",
+          "expr": "sum(${ceph_without_ephemeral} * (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes)) + ((1 - ${ceph_without_ephemeral}) * ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes))))",
           "intervalFactor": 2,
           "legendFormat": "{{aggregate}}",
           "refId": "A",
@@ -1682,21 +1682,21 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "",
-        "description": "Detects if Ceph backend is used without ephemeral storage",
+        "definition": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+        "description": "Detect if Ceph is used as shared backend storage (no ephemeral available)",
         "error": null,
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
-        "label": "Ceph Detection",
+        "label": "Ceph Shared Storage",
         "multi": false,
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 10000000000))",
+          "query": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,
-        "regex": "",
+        "regex": "/.*}\\s+(\\d+)\\s.*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",

--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -1068,7 +1068,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "sum(${ceph_without_ephemeral} * (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes)) + ((1 - ${ceph_without_ephemeral}) * ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes))))",
+          "expr": "sum(${ceph_without_ephemeral} * ((ceph_cluster_total_bytes or vector(0)) - (ceph_cluster_total_used_bytes or vector(0)))) + ((1 - ${ceph_without_ephemeral}) * ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes))))",
           "intervalFactor": 2,
           "legendFormat": "{{aggregate}}",
           "refId": "A",
@@ -1682,7 +1682,7 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+        "definition": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
         "description": "Detect if Ceph is used as shared backend storage (no ephemeral available)",
         "error": null,
         "hide": 0,
@@ -1692,7 +1692,7 @@
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+          "query": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,

--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -1068,7 +1068,7 @@
           "datasource": {
             "uid": "${prometheusds}"
           },
-          "expr": "(${ceph_without_ephemeral} == 1) * (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes) or ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes)))",
+          "expr": "(${ceph_without_ephemeral} * (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes)) or ((sum by(aggregates) (openstack_nova_local_storage_available_bytes * on(hostname) group_left() openstack_placement_resource_allocation_ratio{resourcetype=\"DISK_GB\"})) - (sum by(aggregates) (openstack_nova_local_storage_used_bytes)))",
           "intervalFactor": 2,
           "legendFormat": "{{aggregate}}",
           "refId": "A",
@@ -1692,7 +1692,7 @@
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 5000000000))",
+          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 10000000000))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,

--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -1682,7 +1682,7 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+        "definition": "query_result(max(((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
         "description": "Detect if Ceph is used as shared backend storage (no ephemeral available)",
         "error": null,
         "hide": 0,
@@ -1692,7 +1692,7 @@
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+          "query": "query_result(max(((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -279,7 +279,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "(${ceph_without_ephemeral} * (ceph_cluster_total_used_bytes / clamp_min(ceph_cluster_total_bytes, 1) * 100)) or (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100)",
+          "expr": "sum(${ceph_without_ephemeral} * (ceph_cluster_total_used_bytes / clamp_min(ceph_cluster_total_bytes, 1) * 100)) + ((1 - ${ceph_without_ephemeral}) * (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -621,7 +621,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "(${ceph_without_ephemeral} * ceph_cluster_total_bytes) or sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"})",
+          "expr": "sum(${ceph_without_ephemeral} * ceph_cluster_total_bytes) + ((1 - ${ceph_without_ephemeral}) * sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -2375,22 +2375,24 @@
           "text": "0",
           "value": "0"
         },
-        "datasource": "${prometheusds}",
-        "definition": "",
-        "description": "Detects if Ceph backend is used without ephemeral storage",
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+        "description": "Detect if Ceph is used as shared backend storage (no ephemeral available)",
         "error": null,
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
-        "label": "Ceph Detection",
+        "label": "Ceph Shared Storage",
         "multi": false,
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 10000000000))",
+          "query": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,
-        "regex": "",
+        "regex": "/.*}\\s+(\\d+)\\s.*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": null,

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -279,7 +279,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100",
+          "expr": "(${ceph_without_ephemeral} == 1) * (ceph_cluster_total_used_bytes / clamp_min(ceph_cluster_total_bytes, 1) * 100) or (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -621,7 +621,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"})",
+          "expr": "(${ceph_without_ephemeral} == 1) * ceph_cluster_total_bytes or sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -2367,6 +2367,37 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        },
+        "datasource": "${prometheusds}",
+        "definition": "",
+        "description": "Detects if Ceph backend is used without ephemeral storage",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Ceph Detection",
+        "multi": false,
+        "name": "ceph_without_ephemeral",
+        "options": [],
+        "query": {
+          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 5000000000))",
+          "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -2378,7 +2378,7 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+        "definition": "query_result(max(((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
         "description": "Detect if Ceph is used as shared backend storage (no ephemeral available)",
         "error": null,
         "hide": 0,
@@ -2388,7 +2388,7 @@
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+          "query": "query_result(max(((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -279,7 +279,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(${ceph_without_ephemeral} * (ceph_cluster_total_used_bytes / clamp_min(ceph_cluster_total_bytes, 1) * 100)) + ((1 - ${ceph_without_ephemeral}) * (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100))",
+          "expr": "sum(${ceph_without_ephemeral} * ((ceph_cluster_total_used_bytes or vector(0)) / clamp_min((ceph_cluster_total_bytes or vector(0)), 1) * 100)) + ((1 - ${ceph_without_ephemeral}) * (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -621,7 +621,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "sum(${ceph_without_ephemeral} * ceph_cluster_total_bytes) + ((1 - ${ceph_without_ephemeral}) * sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}))",
+          "expr": "sum(${ceph_without_ephemeral} * (ceph_cluster_total_bytes or vector(0))) + ((1 - ${ceph_without_ephemeral}) * sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -2378,7 +2378,7 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+        "definition": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
         "description": "Detect if Ceph is used as shared backend storage (no ephemeral available)",
         "error": null,
         "hide": 0,
@@ -2388,7 +2388,7 @@
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "query_result(((ceph_cluster_total_bytes > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
+          "query": "query_result((((ceph_cluster_total_bytes or vector(0)) > bool(0)) * scalar(stddev(openstack_nova_local_storage_available_bytes) < bool(1e8)) * scalar(abs(sum(ceph_cluster_total_bytes or vector(0)) - max(openstack_nova_local_storage_available_bytes)) < bool(5e9))))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -279,7 +279,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "(${ceph_without_ephemeral} == 1) * (ceph_cluster_total_used_bytes / clamp_min(ceph_cluster_total_bytes, 1) * 100) or (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100)",
+          "expr": "(${ceph_without_ephemeral} * (ceph_cluster_total_used_bytes / clamp_min(ceph_cluster_total_bytes, 1) * 100)) or (sum(openstack_nova_local_storage_used_bytes{hostname=~\"$hypervisor.*\"}) / sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"}) * 100)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -621,7 +621,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "expr": "(${ceph_without_ephemeral} == 1) * ceph_cluster_total_bytes or sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"})",
+          "expr": "(${ceph_without_ephemeral} * ceph_cluster_total_bytes) or sum(openstack_nova_local_storage_available_bytes{hostname=~\"$hypervisor.*\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -2386,7 +2386,7 @@
         "name": "ceph_without_ephemeral",
         "options": [],
         "query": {
-          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 5000000000))",
+          "query": "bool((ceph_cluster_total_bytes > 0 and stddev(openstack_nova_local_storage_available_bytes) < 1000000000 and abs(ceph_cluster_total_bytes - max(openstack_nova_local_storage_available_bytes)) < 10000000000))",
           "refId": "${prometheusds}-ceph_without_ephemeral-Variable-Query"
         },
         "refresh": 1,


### PR DESCRIPTION
Proposed changes to `OpenStack Cloud Usage` and `OpenStack Compute Overview` dashboards to address https://github.com/canonical/openstack-exporter-operator/issues/154

This solution adds a template variable `ceph_without_ephemeral` for these dashboards to check these conditions: 
-  Ceph storage is detected
-  All compute nodes report same local_gb storage (stddev < 1MB)
- That local_gb storage is very close to the total Ceph total storage (difference < 5GB)

If all checks are true, querying `ceph_without_ephemeral` will return true (`1`), which indicates Ceph is fully used as the storage backend on this deployment and there are likely no ephemeral/instance storage available. In that case, we need to use another expressions for disk calculation, otherwise (return `0`) we fallback to the existing expressions. 

Proposed panels to modify expression are: `Free Disk by Aggregate` (in `OpenStack Cloud Usage`), `Hypervisor Disk Subscription` and its `Total` (from `OpenStack Compute Overview`) 


# Some sample calculations
Case 1 : Current bug
```
Input:  20 nodes × 257TB each = 4.91 PiB (WRONG)
Detection: TRUE (Ceph exists + identical values + values match)
Output: 257TB (Correct)
Result: Correctly report storage
```
Case 2: Identical local storage
```
Input:  20 nodes × 1TB each = 20TB  
Detection: FALSE (no Ceph metrics)
Output: sum(20TB) (UNCHANGED)
Result: No false positive
```
Case 3: Mixed Ceph + Local
```
Input:  Ceph exists [1TB], nodes report [520GB, 500GB, 480GB]
Detection: FALSE (nodes' storage values not identical - stddev > 1MB)  
Output: sum(1500GB) (UNCHANGED)
Result: Correctly preserves mixed storage
```
# Testing
## Default configuration Environment (no Ceph)
-  Jammy Yoga Openstack with local ephemeral storage, with 3 compute nodes from [stsstack-bundles](https://github.com/canonical/stsstack-bundles) 
- `openstack-exporter-operator` with `grafana-agent` subordinate.
- [COS-lite](https://documentation.ubuntu.com/observability/tutorial/installation/cos-lite-microk8s-sandbox/#) on MicroK8s. 
- 3 VM instances each with 20GiB disk created.
### Brief check
```
$ openstack hypervisor list
+----+---------------------------+-----------------+--------------+-------+
| ID | Hypervisor Hostname       | Hypervisor Type | Host IP      | State |
+----+---------------------------+-----------------+--------------+-------+
|  1 | juju-1d5215-yoga-local-9  | QEMU            | 10.149.54.33 | up    |
|  2 | juju-1d5215-yoga-local-8  | QEMU            | 10.149.54.56 | up    |
|  3 | juju-1d5215-yoga-local-10 | QEMU            | 10.149.54.10 | up    |
+----+---------------------------+-----------------+--------------+-------+
openstack hypervisor show -c local_gb juju-1d5215-yoga-local-9
+----------+-------+
| Field    | Value |
+----------+-------+
| local_gb | 49    |
+----------+-------+
openstack hypervisor show -c local_gb juju-1d5215-yoga-local-8
+----------+-------+
| Field    | Value |
+----------+-------+
| local_gb | 49    |
+----------+-------+
openstack hypervisor show -c local_gb juju-1d5215-yoga-local-10
+----------+-------+
| Field    | Value |
+----------+-------+
| local_gb | 49    |
+----------+-------+
```
From `Ceph storage` panel (`OpenStack Cloud Usage`):
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/915b62b1-a833-4c47-afbd-ece6106c09b7" />
### Result:
No Ceph shared storage back end is detected as:
<img width="191" height="41" alt="image" src="https://github.com/user-attachments/assets/c246067a-a06f-4f97-9c07-2c00a92e4530" />

#### OpenStack Cloud Usage
##### Unchanged:
<img width="873" height="211" alt="image" src="https://github.com/user-attachments/assets/50643800-f222-40d5-96b7-dc397405423b" />

#### OpenStack Compute Overview
##### Unchanged:
<img width="434" height="293" alt="image" src="https://github.com/user-attachments/assets/c7263b79-885e-464c-beec-e8278d5668bb" />

## Ceph-shared storage Environment (the issue's case)
-  Jammy Yoga Openstack with Ceph as the shared storage backend, with 3 compute nodes from [stsstack-bundles](https://github.com/canonical/stsstack-bundles) 
- `openstack-exporter-operator` with `grafana-agent` subordinate.
- [COS-lite](https://documentation.ubuntu.com/observability/tutorial/installation/cos-lite-microk8s-sandbox/#) on MicroK8s. 
- 3 VM instances each with 1GiB disk created.
- Add additional relations to scrape for Ceph metrics:
      - From OpenStack model:
      `juju offer ceph-mon:metrics-endpoint`
      
     From COS model:
      `juju consume yoga-ceph.ceph-mon`
      `juju relate ceph-mon:metrics-endpoint prometheus-k8s:metrics-endpoint`
      
     (May need to workaround this [bug](https://discourse.charmhub.io/t/cross-model-relations-and-openstack/519/9))

### Brief check
```
openstack volume service list -c Binary -c State -c Status -c Host  
+------------------+-----------------------------+---------+-------+
| Binary           | Host                        | Status  | State |
+------------------+-----------------------------+---------+-------+
| cinder-scheduler | juju-b7dbae-yoga-ceph-4     | enabled | down  |
| cinder-volume    | juju-b7dbae-yoga-ceph-4@LVM | enabled | down  |
| cinder-volume    | cinder@cinder-ceph          | enabled | up    |
| cinder-scheduler | cinder                      | enabled | up    |
+------------------+-----------------------------+---------+-------+
$ openstack hypervisor list
+----+--------------------------+-----------------+---------------+-------+
| ID | Hypervisor Hostname      | Hypervisor Type | Host IP       | State |
+----+--------------------------+-----------------+---------------+-------+
|  1 | juju-b7dbae-yoga-ceph-12 | QEMU            | 10.149.54.52  | up    |
|  2 | juju-b7dbae-yoga-ceph-21 | QEMU            | 10.149.54.17  | up    |
|  3 | juju-b7dbae-yoga-ceph-20 | QEMU            | 10.149.54.123 | up    |
+----+--------------------------+-----------------+---------------+-------+
$ juju run ceph-mon/0 pool-statistics
CLASS     SIZE    AVAIL    USED    RAW USED    %RAW USED
hdd       30 GiB  25 GiB   5.1 GiB  5.1 GiB    17.07%
TOTAL     30 GiB  25 GiB   5.1 GiB  5.1 GiB    17.07%
$ openstack hypervisor show -c local_gb juju-b7dbae-yoga-ceph-12 
+----------+-------+
| Field    | Value |
+----------+-------+
| local_gb | 29    |
+----------+-------+
$ openstack hypervisor show -c local_gb juju-b7dbae-yoga-ceph-21
+----------+-------+
| Field    | Value |
+----------+-------+
| local_gb | 29    |
+----------+-------+
$ openstack hypervisor show -c local_gb juju-b7dbae-yoga-ceph-20
+----------+-------+
| Field    | Value |
+----------+-------+
| local_gb | 29    |
+----------+-------+
```
From `Ceph storage` panel (`OpenStack Cloud Usage`):
<img width="293" height="294" alt="image" src="https://github.com/user-attachments/assets/cecca349-f456-4b57-aa9c-cd1744244e64" />

### Result:
Ceph shared storage back end is correctly detected for each dashboard, as:
<img width="197" height="42" alt="image" src="https://github.com/user-attachments/assets/b284d1b5-cad9-4065-8b0b-c6f64bce52c7" />

#### OpenStack Cloud Usage
##### Pre:
Free disk usage is incorrectly reported: x3 (total 29 x 3 - 3 allocated = 84 GiB)
<img width="601" height="168" alt="image" src="https://github.com/user-attachments/assets/589b9756-5f1e-4e62-a826-253d5e1d502b" />

##### After:
Free Disk is correctly reported as 24.8 (29.9 - 5.10 used = 24.8 GiB)
<img width="598" height="147" alt="image" src="https://github.com/user-attachments/assets/9125c8f1-3204-4610-94b0-5b4d14a71798" />

#### OpenStack Compute Overview
##### Pre:
Total Disk is incorrectly reported: x3 from actual Ceph cluster storage (29x3 = 87 GiB)
Subscription percentage is incorrect accordingly: 3/87 = 3.45%
<img width="474" height="270" alt="image" src="https://github.com/user-attachments/assets/05f43946-b796-43b6-ba44-8e418102cac0" />

##### After:
Total is correct from actual Ceph cluster storage (29.9 GiB)
Subscription is 5.10/29.9 = 17% (same from the Ceph storage dashboard)
<img width="450" height="305" alt="image" src="https://github.com/user-attachments/assets/f2cb73fa-3aad-4ccb-9e4b-038a7020c15b" />


# Note:
Actual changes should be made from [sunbeam](https://opendev.org/openstack/sunbeam-charms/src/branch/main/charms/openstack-exporter-k8s/src/grafana_dashboards)