### PR TITLE
fix: panel colors for `cloud` and `compute` dashboards

### DIFF
--- a/src/grafana_dashboards/cloud.json
+++ b/src/grafana_dashboards/cloud.json
@@ -568,7 +568,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "rgb(253, 255, 253)",
+                "color": "rgb(229, 231, 235)",
                 "value": null
               }
             ]
@@ -692,7 +692,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "rgb(251, 252, 250)",
+                "color": "rgb(229, 231, 235)",
                 "value": null
               }
             ]
@@ -816,7 +816,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "rgb(251, 252, 250)",
+                "color": "rgb(229, 231, 235)",
                 "value": null
               }
             ]

--- a/src/grafana_dashboards/compute.json
+++ b/src/grafana_dashboards/compute.json
@@ -359,7 +359,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "rgb(251, 252, 250)",
+                "color": "rgb(229, 231, 235)",
                 "value": null
               }
             ]
@@ -473,7 +473,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "rgb(251, 252, 250)",
+                "color": "rgb(229, 231, 235)",
                 "value": null
               }
             ]
@@ -587,7 +587,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "rgb(251, 252, 250)",
+                "color": "rgb(229, 231, 235)",
                 "value": null
               }
             ]


### PR DESCRIPTION
Closes: #164 