### PR TITLE
Update service.json for new agent metrics names

### DIFF
--- a/src/grafana_dashboards/service.json
+++ b/src/grafana_dashboards/service.json
@@ -94,7 +94,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(openstack_nova_agent_state{adminState=\"enabled\"})-sum(openstack_nova_agent_state{adminState=\"enabled\"})",
+          "expr": "count(openstack_nova_agent_state_total{adminState=\"enabled\"})-sum(openstack_nova_agent_state_total{adminState=\"enabled\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -236,7 +236,7 @@
       ],
       "targets": [
         {
-          "expr": "openstack_nova_agent_state{adminState=\"enabled\"}",
+          "expr": "openstack_nova_agent_state_total{adminState=\"enabled\"}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -308,7 +308,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(openstack_nova_agent_state{adminState=\"enabled\"})",
+          "expr": "sum(openstack_nova_agent_state_total{adminState=\"enabled\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -391,7 +391,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(count(openstack_cinder_agent_state{adminState=\"enabled\"})-sum(openstack_cinder_agent_state{adminState=\"enabled\"}))",
+          "expr": "(count(openstack_cinder_agent_state_total{adminState=\"enabled\"})-sum(openstack_cinder_agent_state_total{adminState=\"enabled\"}))",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -625,7 +625,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(openstack_cinder_agent_state{adminState=\"enabled\"})",
+          "expr": "sum(openstack_cinder_agent_state_total{adminState=\"enabled\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -706,7 +706,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(openstack_neutron_agent_state{adminState=\"up\"})-sum(openstack_neutron_agent_state{adminState=\"up\"})",
+          "expr": "count(openstack_neutron_agent_state_total{adminState=\"up\"})-sum(openstack_neutron_agent_state_total{adminState=\"up\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -957,7 +957,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(openstack_neutron_agent_state{adminState=\"up\"})",
+          "expr": "sum(openstack_neutron_agent_state_total{adminState=\"up\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,

--- a/src/grafana_dashboards/service.json
+++ b/src/grafana_dashboards/service.json
@@ -94,7 +94,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(openstack_nova_agent_state_total{adminState=\"enabled\"})-sum(openstack_nova_agent_state_total{adminState=\"enabled\"})",
+          "expr": "count((openstack_nova_agent_state_total{adminState=\"enabled\"} or openstack_nova_agent_state{adminState=\"enabled\"}))-sum((openstack_nova_agent_state_total{adminState=\"enabled\"} or openstack_nova_agent_state{adminState=\"enabled\"}))",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -236,7 +236,7 @@
       ],
       "targets": [
         {
-          "expr": "openstack_nova_agent_state_total{adminState=\"enabled\"}",
+          "expr": "openstack_nova_agent_state_total{adminState=\"enabled\"} or openstack_nova_agent_state{adminState=\"enabled\"}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -308,7 +308,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(openstack_nova_agent_state_total{adminState=\"enabled\"})",
+          "expr": "sum((openstack_nova_agent_state_total{adminState=\"enabled\"} or openstack_nova_agent_state{adminState=\"enabled\"}))",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -391,7 +391,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(count(openstack_cinder_agent_state_total{adminState=\"enabled\"})-sum(openstack_cinder_agent_state_total{adminState=\"enabled\"}))",
+          "expr": "(count((openstack_cinder_agent_state_total{adminState=\"enabled\"} or openstack_cinder_agent_state{adminState=\"enabled\"}))-sum((openstack_cinder_agent_state_total{adminState=\"enabled\"} or openstack_cinder_agent_state{adminState=\"enabled\"})))",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -625,7 +625,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(openstack_cinder_agent_state_total{adminState=\"enabled\"})",
+          "expr": "sum(openstack_cinder_agent_state_total{adminState=\"enabled\"} or openstack_cinder_agent_state{adminState=\"enabled\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -706,7 +706,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(openstack_neutron_agent_state_total{adminState=\"up\"})-sum(openstack_neutron_agent_state_total{adminState=\"up\"})",
+          "expr": "count(openstack_neutron_agent_state_total{adminState=\"up\"} or openstack_neutron_agent_state{adminState=\"up\"})-sum(openstack_neutron_agent_state_total{adminState=\"up\"} or openstack_neutron_agent_state{adminState=\"up\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -957,7 +957,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(openstack_neutron_agent_state_total{adminState=\"up\"})",
+          "expr": "sum(openstack_neutron_agent_state_total{adminState=\"up\"} or openstack_neutron_agent_state{adminState=\"up\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,


### PR DESCRIPTION
Nova, Cinder and Neutron agent metric names changed to openstack_<service>_agent_total from openstack_<service>_agent.