### PR TITLE
support Noble and add noble-caracal bundle test

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,7 +14,7 @@ parts:
     source: .
 
 platforms:
-  ubuntu@22.04:amd64:
+  # ubuntu@22.04:amd64:  # temporarily disabled to speed up Noble CI verification
   ubuntu@24.04:amd64:
 
 requires:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,7 +14,7 @@ parts:
     source: .
 
 platforms:
-  # ubuntu@22.04:amd64:  # temporarily disabled to speed up Noble CI verification
+  ubuntu@22.04:amd64:
   ubuntu@24.04:amd64:
 
 requires:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,6 +15,7 @@ parts:
 
 platforms:
   ubuntu@22.04:amd64:
+  ubuntu@24.04:amd64:
 
 requires:
   credentials:

--- a/tests/functional/tests/bundles/noble-caracal.yaml
+++ b/tests/functional/tests/bundles/noble-caracal.yaml
@@ -6,9 +6,9 @@ applications:
   openstack-exporter:
     charm: openstack-exporter  # To be overridden by overlay
     num_units: 1
-  opentelemetry-collector:
-    charm: opentelemetry-collector
-    channel: 2/stable
+  grafana-agent:
+    charm: grafana-agent
+    channel: 1/stable
   keystone:
     charm: keystone
     channel: latest/edge
@@ -201,5 +201,5 @@ relations:
   - vault:certificates
 - - openstack-exporter:credentials
   - keystone:identity-admin
-- - opentelemetry-collector:cos-agent
+- - grafana-agent:cos-agent
   - openstack-exporter:cos-agent

--- a/tests/functional/tests/bundles/noble-caracal.yaml
+++ b/tests/functional/tests/bundles/noble-caracal.yaml
@@ -1,0 +1,205 @@
+variables:
+  openstack-origin: &openstack-origin distro
+series: jammy
+
+applications:
+  openstack-exporter:
+    charm: openstack-exporter  # To be overridden by overlay
+    num_units: 1
+  grafana-agent:
+    charm: grafana-agent
+    channel: stable
+  keystone:
+    charm: keystone
+    channel: yoga/edge
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: arch=amd64 mem=1024
+  keystone-mysql-router:
+    charm: mysql-router
+    channel: latest/edge
+  vault:
+    charm: vault
+    channel: latest/edge
+    num_units: 1
+  vault-mysql-router:
+    charm: mysql-router
+    channel: latest/edge
+  mysql:
+    charm: mysql-innodb-cluster
+    channel: latest/edge
+    options:
+      source: *openstack-origin
+    num_units: 3
+    constraints: arch=amd64 mem=4096
+  glance:
+    charm: glance
+    channel: yoga/edge
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: arch=amd64 mem=1024
+  glance-mysql-router:
+    charm: mysql-router
+    channel: latest/edge
+  nova-compute:
+    charm: nova-compute
+    channel: yoga/edge
+    num_units: 1
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      encrypt: true
+      force-raw-images: true
+      libvirt-image-backend: rbd
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+      verbose: true
+      debug: true
+    constraints: arch=amd64 mem=4096
+  nova-cloud-controller-mysql-router:
+    charm: mysql-router
+    channel: latest/edge
+  nova-cloud-controller:
+    charm: nova-cloud-controller
+    channel: yoga/edge
+    num_units: 1
+    options:
+      debug: true
+      network-manager: Neutron
+      openstack-origin: distro
+      verbose: true
+    constraints: arch=amd64 mem=2048
+  neutron-api:
+    charm: neutron-api
+    channel: yoga/edge
+    num_units: 1
+    options:
+      debug: true
+      flat-network-providers: physnet1
+      manage-neutron-plugin-legacy-mode: false
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+      path-mtu: 1550
+      physical-network-mtus: physnet1:1500
+      verbose: true
+    constraints: arch=amd64 mem=2048
+  neutron-api-mysql-router:
+    charm: mysql-router
+    channel: latest/edge
+  rabbitmq-server:
+    charm: rabbitmq-server
+    channel: 3.9/stable
+    num_units: 1
+    options:
+      min-cluster-size: 1
+    constraints: arch=amd64 mem=1024
+  placement:
+    charm: placement
+    channel: yoga/edge
+    num_units: 1
+    options:
+      debug: true
+      openstack-origin: *openstack-origin
+    constraints: arch=amd64 mem=1024
+  placement-mysql-router:
+    charm: mysql-router
+    channel: latest/edge
+  neutron-api-plugin-ovn:
+    charm: neutron-api-plugin-ovn
+    channel: yoga/edge
+  ovn-central:
+    charm: ovn-central
+    channel: 22.03/stable
+    num_units: 3
+    options:
+      source: distro
+    constraints: arch=amd64 mem=2048
+  ovn-chassis:
+    charm: ovn-chassis
+    channel: 22.03/stable
+    options:
+      debug: true
+      ovn-bridge-mappings: physnet1:br-data
+relations:
+- - nova-cloud-controller:shared-db
+  - nova-cloud-controller-mysql-router:shared-db
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:shared-db
+  - neutron-api-mysql-router:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance:identity-service
+  - keystone:identity-service
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - nova-compute:secrets-storage
+  - vault:secrets
+- - glance:certificates
+  - vault:certificates
+- - keystone:certificates
+  - vault:certificates
+- - neutron-api:certificates
+  - vault:certificates
+- - nova-cloud-controller:certificates
+  - vault:certificates
+- - placement:certificates
+  - vault:certificates
+- - mysql:db-router
+  - glance-mysql-router:db-router
+- - mysql:db-router
+  - keystone-mysql-router:db-router
+- - mysql:db-router
+  - neutron-api-mysql-router:db-router
+- - mysql:db-router
+  - nova-cloud-controller-mysql-router:db-router
+- - mysql:db-router
+  - placement-mysql-router:db-router
+- - mysql:db-router
+  - vault-mysql-router:db-router
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - neutron-api-plugin-ovn:ovsdb-cms
+  - ovn-central:ovsdb-cms
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - neutron-api-plugin-ovn:certificates
+  - vault:certificates
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-chassis:certificates
+  - vault:certificates
+- - openstack-exporter:credentials
+  - keystone:identity-admin
+- - grafana-agent:cos-agent
+  - openstack-exporter:cos-agent

--- a/tests/functional/tests/bundles/noble-caracal.yaml
+++ b/tests/functional/tests/bundles/noble-caracal.yaml
@@ -1,17 +1,17 @@
 variables:
   openstack-origin: &openstack-origin distro
-series: jammy
+series: noble
 
 applications:
   openstack-exporter:
     charm: openstack-exporter  # To be overridden by overlay
     num_units: 1
-  grafana-agent:
-    charm: grafana-agent
-    channel: stable
+  opentelemetry-collector:
+    charm: opentelemetry-collector
+    channel: 2/stable
   keystone:
     charm: keystone
-    channel: yoga/edge
+    channel: latest/edge
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -35,7 +35,7 @@ applications:
     constraints: arch=amd64 mem=4096
   glance:
     charm: glance
-    channel: yoga/edge
+    channel: latest/edge
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -45,7 +45,7 @@ applications:
     channel: latest/edge
   nova-compute:
     charm: nova-compute
-    channel: yoga/edge
+    channel: latest/edge
     num_units: 1
     options:
       enable-live-migration: true
@@ -63,7 +63,7 @@ applications:
     channel: latest/edge
   nova-cloud-controller:
     charm: nova-cloud-controller
-    channel: yoga/edge
+    channel: latest/edge
     num_units: 1
     options:
       debug: true
@@ -73,7 +73,7 @@ applications:
     constraints: arch=amd64 mem=2048
   neutron-api:
     charm: neutron-api
-    channel: yoga/edge
+    channel: latest/edge
     num_units: 1
     options:
       debug: true
@@ -90,14 +90,14 @@ applications:
     channel: latest/edge
   rabbitmq-server:
     charm: rabbitmq-server
-    channel: 3.9/stable
+    channel: latest/edge
     num_units: 1
     options:
       min-cluster-size: 1
     constraints: arch=amd64 mem=1024
   placement:
     charm: placement
-    channel: yoga/edge
+    channel: latest/edge
     num_units: 1
     options:
       debug: true
@@ -108,17 +108,17 @@ applications:
     channel: latest/edge
   neutron-api-plugin-ovn:
     charm: neutron-api-plugin-ovn
-    channel: yoga/edge
+    channel: latest/edge
   ovn-central:
     charm: ovn-central
-    channel: 22.03/stable
+    channel: latest/edge
     num_units: 3
     options:
       source: distro
     constraints: arch=amd64 mem=2048
   ovn-chassis:
     charm: ovn-chassis
-    channel: 22.03/stable
+    channel: latest/edge
     options:
       debug: true
       ovn-bridge-mappings: physnet1:br-data
@@ -201,5 +201,5 @@ relations:
   - vault:certificates
 - - openstack-exporter:credentials
   - keystone:identity-admin
-- - grafana-agent:cos-agent
+- - opentelemetry-collector:cos-agent
   - openstack-exporter:cos-agent

--- a/tests/functional/tests/bundles/overlays/noble-caracal.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/noble-caracal.yaml.j2
@@ -1,7 +1,6 @@
 applications:
   {{ charm_name }}:
     charm: {{ CHARM_PATH_NOBLE }}
-    base: ubuntu@24.04
     exposed-endpoints:
       "":
         expose-to-cidrs:

--- a/tests/functional/tests/bundles/overlays/noble-caracal.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/noble-caracal.yaml.j2
@@ -1,0 +1,15 @@
+applications:
+  {{ charm_name }}:
+    charm: {{ CHARM_PATH_NOBLE }}
+    base: ubuntu@24.04
+    exposed-endpoints:
+      "":
+        expose-to-cidrs:
+        - 0.0.0.0/0
+        - ::/0
+  vault:
+    exposed-endpoints:
+      "":
+        expose-to-cidrs:
+        - 0.0.0.0/0
+        - ::/0

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -1,6 +1,6 @@
 charm_name: openstack-exporter
 gate_bundles:
-  - jammy-yoga
+  # - jammy-yoga  # temporarily disabled to speed up Noble CI verification
   - noble-caracal
 configure:
   - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation_no_wait
@@ -30,3 +30,6 @@ target_deploy_status:
   grafana-agent:
     workload-status: blocked
     workload-status-message-regex: "^Missing .* for cos-agent$"
+  opentelemetry-collector:
+    workload-status: blocked
+    workload-status-message-regex: ".* for cos-agent$"

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -1,6 +1,7 @@
 charm_name: openstack-exporter
 gate_bundles:
   - jammy-yoga
+  - noble-caracal
 configure:
   - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation_no_wait
   - tests.charm_tests.setup.setup_export_ssl_ca_config

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -30,6 +30,3 @@ target_deploy_status:
   grafana-agent:
     workload-status: blocked
     workload-status-message-regex: "^Missing .* for cos-agent$"
-  opentelemetry-collector:
-    workload-status: blocked
-    workload-status-message-regex: ".* for cos-agent$"

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -1,6 +1,6 @@
 charm_name: openstack-exporter
 gate_bundles:
-  # - jammy-yoga  # temporarily disabled to speed up Noble CI verification
+  - jammy-yoga
   - noble-caracal
 configure:
   - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation_no_wait


### PR DESCRIPTION
Support build for Noble and add a Noble-Caracal bundle to test the Noble build. 

The charms and channels for the bundle are referenced from [stsstack-bundles](https://github.com/canonical/stsstack-bundles) when deploying with noble-caracal options.

Build and func test passed in [this run](https://github.com/canonical/openstack-exporter-operator/actions/runs/25485252344/job/74780591950).

The test bundle still uses grafana-agent instead of otel-col because func test still refers to g-a, needs to wait for https://github.com/canonical/openstack-exporter-operator/pull/185 to support otel-col first.

Close #195 
