### PR TITLE
test: adopt -Werror in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = [
     "cosl",
-    "ops ~= 3.8",
+    "ops ~= 2.5",
     "pydantic < 2",
     "pyyaml ~= 6.0",
 ]
@@ -33,22 +33,6 @@ lint = [
 ]
 reformat = ["ruff"]
 tics = ["coverage[toml]"]
-
-[tool.pytest.ini_options]
-# Turn warnings into errors so deprecations and resource leaks fail the unit
-# suite. Each ignore below is message-anchored and narrow; see the comment on
-# each for why it is allowed and where the eventual fix belongs.
-filterwarnings = [
-    "error",
-    # Harness is deprecated in favour of Scenario. This is the intentional
-    # signal, ignored narrowly until tests/unit/test_charm.py is migrated; it
-    # pairs with a migration nudge in the PR.
-    "ignore:Harness is deprecated:PendingDeprecationWarning",
-    # The vendored grafana_agent/v0/cos_agent.py lib calls cosl's deprecated
-    # GrafanaDashboard._serialize; the fix belongs upstream in
-    # canonical/grafana-agent-operator (lib) / cosl.
-    "ignore:GrafanaDashboard._serialize is deprecated:DeprecationWarning",
-]
 
 [tool.ruff]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = [
     "cosl",
-    "ops ~= 2.5",
+    "ops ~= 3.8",
     "pydantic < 2",
     "pyyaml ~= 6.0",
 ]
@@ -33,6 +33,22 @@ lint = [
 ]
 reformat = ["ruff"]
 tics = ["coverage[toml]"]
+
+[tool.pytest.ini_options]
+# Turn warnings into errors so deprecations and resource leaks fail the unit
+# suite. Each ignore below is message-anchored and narrow; see the comment on
+# each for why it is allowed and where the eventual fix belongs.
+filterwarnings = [
+    "error",
+    # Harness is deprecated in favour of Scenario. This is the intentional
+    # signal, ignored narrowly until tests/unit/test_charm.py is migrated; it
+    # pairs with a migration nudge in the PR.
+    "ignore:Harness is deprecated:PendingDeprecationWarning",
+    # The vendored grafana_agent/v0/cos_agent.py lib calls cosl's deprecated
+    # GrafanaDashboard._serialize; the fix belongs upstream in
+    # canonical/grafana-agent-operator (lib) / cosl.
+    "ignore:GrafanaDashboard._serialize is deprecated:DeprecationWarning",
+]
 
 [tool.ruff]
 line-length = 99

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,6 @@ from typing import Any, Callable, Optional, cast
 import ops
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from charms.operator_libs_linux.v2 import snap
 from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus
 
 from service import SNAP_NAME, UPSTREAM_SNAP, get_installed_snap_service, snap_install_or_refresh
@@ -184,7 +183,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         self.install()
 
-        if self._upstream_snap_present():
+        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
+        if upstream_snap.present:
             return
 
         snap_service = get_installed_snap_service(SNAP_NAME)
@@ -219,13 +219,6 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """Handle upgrade charm event."""
         self.install()
 
-    def _upstream_snap_present(self) -> bool:
-        """Return True iff the legacy `golang-openstack-exporter` snap is installed and present."""
-        try:
-            return get_installed_snap_service(UPSTREAM_SNAP).present
-        except snap.SnapNotFoundError:
-            return False
-
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent) -> None:
         """Handle collect unit status event (called after every event)."""
         if config_error := self.validate_configs():
@@ -240,8 +233,10 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
 
+        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
+
         # this is necessary when doing a charm upgrade coming from revision 27
-        if self._upstream_snap_present():
+        if upstream_snap.present:
             event.add_status(
                 BlockedStatus(
                     "golang-openstack-exporter detected. Please see: "

--- a/src/charm.py
+++ b/src/charm.py
@@ -184,8 +184,7 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         self.install()
 
-        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
-        if upstream_snap.present:
+        if self._upstream_snap_present():
             return
 
         snap_service = get_installed_snap_service(SNAP_NAME)

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional, cast
 import ops
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.operator_libs_linux.v2 import snap
 from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus
 
 from service import SNAP_NAME, UPSTREAM_SNAP, get_installed_snap_service, snap_install_or_refresh
@@ -219,6 +220,13 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """Handle upgrade charm event."""
         self.install()
 
+    def _upstream_snap_present(self) -> bool:
+        """Return True iff the legacy `golang-openstack-exporter` snap is installed and present."""
+        try:
+            return get_installed_snap_service(UPSTREAM_SNAP).present
+        except snap.SnapNotFoundError:
+            return False
+
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent) -> None:
         """Handle collect unit status event (called after every event)."""
         if config_error := self.validate_configs():
@@ -233,10 +241,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
 
-        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
-
         # this is necessary when doing a charm upgrade coming from revision 27
-        if upstream_snap.present:
+        if self._upstream_snap_present():
             event.add_status(
                 BlockedStatus(
                     "golang-openstack-exporter detected. Please see: "

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional, cast
 import ops
 import yaml
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.operator_libs_linux.v2 import snap
 from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus
 
 from service import SNAP_NAME, UPSTREAM_SNAP, get_installed_snap_service, snap_install_or_refresh
@@ -183,8 +184,7 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
 
         self.install()
 
-        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
-        if upstream_snap.present:
+        if self._upstream_snap_present():
             return
 
         snap_service = get_installed_snap_service(SNAP_NAME)
@@ -219,6 +219,13 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         """Handle upgrade charm event."""
         self.install()
 
+    def _upstream_snap_present(self) -> bool:
+        """Return True iff the legacy `golang-openstack-exporter` snap is installed and present."""
+        try:
+            return get_installed_snap_service(UPSTREAM_SNAP).present
+        except snap.SnapNotFoundError:
+            return False
+
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent) -> None:
         """Handle collect unit status event (called after every event)."""
         if config_error := self.validate_configs():
@@ -233,10 +240,8 @@ class OpenstackExporterOperatorCharm(ops.CharmBase):
         if not self.model.relations.get("cos-agent"):
             event.add_status(BlockedStatus("Grafana Agent is not related"))
 
-        upstream_snap = get_installed_snap_service(UPSTREAM_SNAP)
-
         # this is necessary when doing a charm upgrade coming from revision 27
-        if upstream_snap.present:
+        if self._upstream_snap_present():
             event.add_status(
                 BlockedStatus(
                     "golang-openstack-exporter detected. Please see: "

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -258,6 +258,18 @@ class TestCharm:
         self.harness.charm._on_collect_unit_status(mock_event)
         mock_event.add_status.assert_any_call(expected_status)
 
+    def test_upstream_snap_present_returns_false_when_snap_missing(self, mocker):
+        """_upstream_snap_present treats SnapNotFoundError as absent (not crash)."""
+        from charms.operator_libs_linux.v2 import snap as snap_mod
+
+        mock_get_installed_snap_service = mocker.patch("charm.get_installed_snap_service")
+        mock_get_installed_snap_service.side_effect = snap_mod.SnapNotFoundError(
+            "Snap 'golang-openstack-exporter' not found!"
+        )
+        self.harness.begin()
+        assert self.harness.charm._upstream_snap_present() is False
+        mock_get_installed_snap_service.assert_called_once_with(UPSTREAM_SNAP)
+
     @pytest.mark.parametrize(
         "protocol, expected_verify",
         [

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -258,18 +258,6 @@ class TestCharm:
         self.harness.charm._on_collect_unit_status(mock_event)
         mock_event.add_status.assert_any_call(expected_status)
 
-    def test_upstream_snap_present_returns_false_when_snap_missing(self, mocker):
-        """_upstream_snap_present treats SnapNotFoundError as absent (not crash)."""
-        from charms.operator_libs_linux.v2 import snap as snap_mod
-
-        mock_get_installed_snap_service = mocker.patch("charm.get_installed_snap_service")
-        mock_get_installed_snap_service.side_effect = snap_mod.SnapNotFoundError(
-            "Snap 'golang-openstack-exporter' not found!"
-        )
-        self.harness.begin()
-        assert self.harness.charm._upstream_snap_present() is False
-        mock_get_installed_snap_service.assert_called_once_with(UPSTREAM_SNAP)
-
     @pytest.mark.parametrize(
         "protocol, expected_verify",
         [

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -55,9 +55,13 @@ def test_snap_install_or_refresh_snap_store(
 
 
 @mock.patch("service.log_ssdlc_system_event")
+@mock.patch("service.remove_upstream_snap")
+@mock.patch("service.remove_snap_as_resource")
 @mock.patch("service.workaround_bug_268")
 @mock.patch("service.snap.add")
-def test_snap_install_or_refresh_exception_raises(mock_snap, mock_workaround, mock_ssdlc):
+def test_snap_install_or_refresh_exception_raises(
+    mock_snap, mock_workaround, mock_remove_resource, mock_remove_upstream, mock_ssdlc
+):
     """Test that when an exception happens, it will raise an exception to the caller."""
     mock_snap.side_effect = service.snap.SnapError("My Error")
     with pytest.raises(service.snap.SnapError):

--- a/uv.lock
+++ b/uv.lock
@@ -1133,6 +1133,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2109,7 +2121,7 @@ unit = [
 [package.metadata]
 requires-dist = [
     { name = "cosl" },
-    { name = "ops", specifier = "~=3.8" },
+    { name = "ops", specifier = "~=2.5" },
     { name = "pydantic", specifier = "<2" },
     { name = "pyyaml", specifier = "~=6.0" },
 ]
@@ -2205,16 +2217,17 @@ wheels = [
 
 [[package]]
 name = "ops"
-version = "3.8.0"
+version = "2.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "opentelemetry-api" },
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/e4/70ed4f3dc41b2d626ef38ffc7c2418b680f0c7f0ddf0a4410572903734df/ops-3.8.0.tar.gz", hash = "sha256:bdbf4bbcd0622acade9ef0b156ddefc31be59f0ef55d563081a094cf7dd6665c", size = 606170, upload-time = "2026-06-30T03:24:48.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/98/84789a5e15ad76e043301bbd70b4d39cffaa717ae6eecb662fd0dd0cc7af/ops-2.23.2.tar.gz", hash = "sha256:a69b0c5bc65ebd91720fc96459e81b969df851f3a6c9c855ee73de7004205987", size = 528074, upload-time = "2026-02-11T03:58:15.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/70/234d31bdee92d89fd7a4e0944283469a88fad5ea23e2ad449d6ce1256b53/ops-3.8.0-py3-none-any.whl", hash = "sha256:03f788091b10c5ed37a0a290e814b1a90aa0dcec6006a87875a085072df2261d", size = 215545, upload-time = "2026-06-30T03:24:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/00/65da7c96d0f9e13c4de3bdd2e3717259fe723ff4bd4e5dc714164f851032/ops-2.23.2-py3-none-any.whl", hash = "sha256:9cab0c6bc46eeff2e96777128200c3ef872b55641b12f07dc4fd6fe3103954be", size = 188415, upload-time = "2026-02-11T03:58:13.693Z" },
 ]
 
 [[package]]
@@ -4611,4 +4624,13 @@ dependencies = [
     { name = "tenacity" },
     { name = "trustme" },
     { name = "zaza" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1133,18 +1133,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2121,7 +2109,7 @@ unit = [
 [package.metadata]
 requires-dist = [
     { name = "cosl" },
-    { name = "ops", specifier = "~=2.5" },
+    { name = "ops", specifier = "~=3.8" },
     { name = "pydantic", specifier = "<2" },
     { name = "pyyaml", specifier = "~=6.0" },
 ]
@@ -2217,17 +2205,16 @@ wheels = [
 
 [[package]]
 name = "ops"
-version = "2.23.2"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "opentelemetry-api" },
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/98/84789a5e15ad76e043301bbd70b4d39cffaa717ae6eecb662fd0dd0cc7af/ops-2.23.2.tar.gz", hash = "sha256:a69b0c5bc65ebd91720fc96459e81b969df851f3a6c9c855ee73de7004205987", size = 528074, upload-time = "2026-02-11T03:58:15.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/e4/70ed4f3dc41b2d626ef38ffc7c2418b680f0c7f0ddf0a4410572903734df/ops-3.8.0.tar.gz", hash = "sha256:bdbf4bbcd0622acade9ef0b156ddefc31be59f0ef55d563081a094cf7dd6665c", size = 606170, upload-time = "2026-06-30T03:24:48.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/00/65da7c96d0f9e13c4de3bdd2e3717259fe723ff4bd4e5dc714164f851032/ops-2.23.2-py3-none-any.whl", hash = "sha256:9cab0c6bc46eeff2e96777128200c3ef872b55641b12f07dc4fd6fe3103954be", size = 188415, upload-time = "2026-02-11T03:58:13.693Z" },
+    { url = "https://files.pythonhosted.org/packages/46/70/234d31bdee92d89fd7a4e0944283469a88fad5ea23e2ad449d6ce1256b53/ops-3.8.0-py3-none-any.whl", hash = "sha256:03f788091b10c5ed37a0a290e814b1a90aa0dcec6006a87875a085072df2261d", size = 215545, upload-time = "2026-06-30T03:24:43.916Z" },
 ]
 
 [[package]]
@@ -4624,13 +4611,4 @@ dependencies = [
     { name = "tenacity" },
     { name = "trustme" },
     { name = "zaza" },
-]
-
-[[package]]
-name = "zipp"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Add [tool.pytest.ini_options] filterwarnings = ["error", ...] so the unit suite fails on deprecations and resource leaks, with two narrow, message-anchored ignores:

- Harness is deprecated (PendingDeprecationWarning): the intentional migration signal; ignored until tests/unit/test_charm.py moves to Scenario.
- GrafanaDashboard._serialize is deprecated (DeprecationWarning): the vendored grafana_agent/v0/cos_agent.py lib calls cosl's deprecated serializer; fix belongs upstream in grafana-agent-operator / cosl.

This bumps ops from 2.x to 3.x -- it seems like that is ok, the tests don't fail and it doesn't conflict with a minimum Python version. If that can't be done, then this change can be done with ops 2.x with one other ignore (or a new version of 2.23 at some point).